### PR TITLE
Fix: Improve Handling of Duplicate IntelliJ API Keys and Enhance Key Validation Logic

### DIFF
--- a/src/main/kotlin/org/zhavoronkov/openrouter/icons/OpenRouterIcons.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/icons/OpenRouterIcons.kt
@@ -11,9 +11,9 @@ import javax.swing.Icon
  */
 object OpenRouterIcons {
 
-    /** Icon for the tool window (16x16) */
+    /** Icon for the tool window (13x13 as required by IntelliJ) */
     @JvmField
-    val TOOL_WINDOW: Icon = IconLoader.getIcon("/icons/openrouter-16.png", OpenRouterIcons::class.java)
+    val TOOL_WINDOW: Icon = IconLoader.getIcon("/icons/openrouter-13.png", OpenRouterIcons::class.java)
 
     /** Icon for the status bar widget (13x13) */
     @JvmField

--- a/src/main/kotlin/org/zhavoronkov/openrouter/listeners/PluginLifecycleListener.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/listeners/PluginLifecycleListener.kt
@@ -6,6 +6,7 @@ import org.zhavoronkov.openrouter.proxy.servlets.RequestValidator
 import org.zhavoronkov.openrouter.services.OpenRouterProxyService
 import org.zhavoronkov.openrouter.services.OpenRouterSettingsService
 import org.zhavoronkov.openrouter.utils.ModelAvailabilityNotifier
+import org.zhavoronkov.openrouter.utils.PasswordSafeKeyStorage
 import org.zhavoronkov.openrouter.utils.PluginLogger
 
 /**
@@ -71,5 +72,10 @@ class PluginLifecycleListener : DynamicPluginListener {
 
         PluginLogger.Service.info("OpenRouter plugin loaded: version ${pluginDescriptor.version}")
         PluginLogger.Service.info("Dynamic plugin support: enabled")
+
+        // Preload API keys from PasswordSafe on background thread
+        // This prevents EDT violations when keys are accessed from UI components
+        PasswordSafeKeyStorage.preloadKeys()
+        PluginLogger.Service.debug("PasswordSafe key preload triggered")
     }
 }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/models/OpenRouterModels.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/models/OpenRouterModels.kt
@@ -156,25 +156,20 @@ data class ModelPricing(
     val request: String? = null
 )
 
-// Legacy model info for backward compatibility
-data class ModelInfo(
-    val id: String,
-    val name: String,
-    val description: String? = null,
-    val pricing: ModelPricing? = null
-)
-
 /**
- * Generation tracking data
+ * Generation tracking data.
+ *
+ * Properties are mutable (`var`) with default values for IntelliJ XML serialization.
+ * See: https://jb.gg/ij-psoc
  */
 data class GenerationTrackingInfo(
-    val generationId: String,
-    val model: String,
-    val timestamp: Long,
-    val promptTokens: Int? = null,
-    val completionTokens: Int? = null,
-    val totalTokens: Int? = null,
-    val totalCost: Double? = null
+    var generationId: String = "",
+    var model: String = "",
+    var timestamp: Long = 0L,
+    var promptTokens: Int? = null,
+    var completionTokens: Int? = null,
+    var totalTokens: Int? = null,
+    var totalCost: Double? = null
 )
 
 /**

--- a/src/main/kotlin/org/zhavoronkov/openrouter/settings/ApiKeyManager.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/settings/ApiKeyManager.kt
@@ -1,11 +1,12 @@
 package org.zhavoronkov.openrouter.settings
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.ui.Messages
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.zhavoronkov.openrouter.models.ApiKeyInfo
 import org.zhavoronkov.openrouter.models.ApiResult
 import org.zhavoronkov.openrouter.services.OpenRouterService
@@ -17,6 +18,7 @@ import javax.swing.JTable
 /**
  * Handles API key management operations for OpenRouter settings
  */
+@Suppress("TooManyFunctions")
 class ApiKeyManager(
     private val settingsService: OpenRouterSettingsService,
     private val openRouterService: OpenRouterService,
@@ -31,6 +33,7 @@ class ApiKeyManager(
 
     private val dialogManager = ApiKeyDialogManager()
     private val intellijKeyManager = IntellijApiKeyManager(settingsService, openRouterService)
+    private val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     // Cache for API keys to avoid redundant API calls during settings dialog initialization
     private var cachedApiKeys: List<ApiKeyInfo>? = null
@@ -61,42 +64,49 @@ class ApiKeyManager(
     }
 
     private fun createApiKeyAsync(label: String) {
-        val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-        scope.launch {
+        coroutineScope.launch(Dispatchers.IO) {
             try {
                 val result = openRouterService.createApiKey(label)
-                when (result) {
-                    is ApiResult.Success -> {
-                        PluginLogger.Settings.info("Successfully created API key with label: $label")
-                        dialogManager.showApiKeyDialog(result.data.key, label)
-                        refreshApiKeys()
+                ApplicationManager.getApplication().invokeLater({
+                    when (result) {
+                        is ApiResult.Success -> {
+                            PluginLogger.Settings.info("Successfully created API key with label: $label")
+                            dialogManager.showApiKeyDialog(result.data.key, label)
+                            refreshApiKeys()
+                        }
+                        is ApiResult.Error -> {
+                            PluginLogger.Settings.error("API call failed during key creation: ${result.message}")
+                            Messages.showErrorDialog(
+                                "Failed to create API key: ${result.message}",
+                                "API Key Creation Failed"
+                            )
+                        }
                     }
-                    is ApiResult.Error -> {
-                        PluginLogger.Settings.error("API call failed during key creation: ${result.message}")
-                        Messages.showErrorDialog(
-                            "Failed to create API key: ${result.message}",
-                            "API Key Creation Failed"
-                        )
-                    }
-                }
+                }, ModalityState.any())
             } catch (e: IllegalStateException) {
                 PluginLogger.Settings.error("Invalid state during key creation: ${e.message}", e)
-                Messages.showErrorDialog(
-                    "Failed to create API key due to invalid state. Please try again.",
-                    "API Key Creation Failed"
-                )
+                ApplicationManager.getApplication().invokeLater({
+                    Messages.showErrorDialog(
+                        "Failed to create API key due to invalid state. Please try again.",
+                        "API Key Creation Failed"
+                    )
+                }, ModalityState.any())
             } catch (e: IOException) {
                 PluginLogger.Settings.error("Network error during key creation: ${e.message}", e)
-                Messages.showErrorDialog(
-                    "Failed to create API key due to network error. Please try again.",
-                    "API Key Creation Failed"
-                )
+                ApplicationManager.getApplication().invokeLater({
+                    Messages.showErrorDialog(
+                        "Failed to create API key due to network error. Please try again.",
+                        "API Key Creation Failed"
+                    )
+                }, ModalityState.any())
             } catch (expectedError: Exception) {
                 PluginLogger.Settings.error("Exception during key creation: ${expectedError.message}", expectedError)
-                Messages.showErrorDialog(
-                    "Failed to create API key due to error. Please try again.",
-                    "API Key Creation Failed"
-                )
+                ApplicationManager.getApplication().invokeLater({
+                    Messages.showErrorDialog(
+                        "Failed to create API key due to error. Please try again.",
+                        "API Key Creation Failed"
+                    )
+                }, ModalityState.any())
             }
         }
     }
@@ -127,43 +137,48 @@ class ApiKeyManager(
     }
 
     private fun performApiKeyDeletion(apiKey: ApiKeyInfo, selectedRow: Int) {
-        val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-        scope.launch {
+        coroutineScope.launch(Dispatchers.IO) {
             try {
                 val deleteResult = openRouterService.deleteApiKey(apiKey.hash)
-                when (deleteResult) {
-                    is ApiResult.Success -> {
-                        if (deleteResult.data.deleted) {
-                            PluginLogger.Settings.info("Successfully deleted API key: ${apiKey.name}")
-                            apiKeyTableModel.removeApiKey(selectedRow)
-                            Messages.showInfoMessage("API key deleted successfully.", "Success")
-                        } else {
+                ApplicationManager.getApplication().invokeLater({
+                    when (deleteResult) {
+                        is ApiResult.Success -> {
+                            if (deleteResult.data.deleted) {
+                                PluginLogger.Settings.info("Successfully deleted API key: ${apiKey.name}")
+                                apiKeyTableModel.removeApiKey(selectedRow)
+                                Messages.showInfoMessage("API key deleted successfully.", "Success")
+                            } else {
+                                Messages.showErrorDialog(
+                                    "Failed to delete API key. Please try again.",
+                                    "Deletion Failed"
+                                )
+                            }
+                        }
+                        is ApiResult.Error -> {
+                            PluginLogger.Settings.error("API call failed during key deletion: ${deleteResult.message}")
                             Messages.showErrorDialog(
-                                "Failed to delete API key. Please try again.",
+                                "Failed to delete API key: ${deleteResult.message}",
                                 "Deletion Failed"
                             )
                         }
                     }
-                    is ApiResult.Error -> {
-                        PluginLogger.Settings.error("API call failed during key deletion: ${deleteResult.message}")
-                        Messages.showErrorDialog(
-                            "Failed to delete API key: ${deleteResult.message}",
-                            "Deletion Failed"
-                        )
-                    }
-                }
+                }, ModalityState.any())
             } catch (e: IllegalStateException) {
                 PluginLogger.Settings.error("Invalid state during key deletion: ${e.message}", e)
-                Messages.showErrorDialog(
-                    "Failed to delete API key due to error. Please try again.",
-                    "Deletion Failed"
-                )
+                ApplicationManager.getApplication().invokeLater({
+                    Messages.showErrorDialog(
+                        "Failed to delete API key due to error. Please try again.",
+                        "Deletion Failed"
+                    )
+                }, ModalityState.any())
             } catch (e: IOException) {
                 PluginLogger.Settings.error("Network error during key deletion: ${e.message}", e)
-                Messages.showErrorDialog(
-                    "Failed to delete API key due to error. Please try again.",
-                    "Deletion Failed"
-                )
+                ApplicationManager.getApplication().invokeLater({
+                    Messages.showErrorDialog(
+                        "Failed to delete API key due to error. Please try again.",
+                        "Deletion Failed"
+                    )
+                }, ModalityState.any())
             }
         }
     }
@@ -173,10 +188,14 @@ class ApiKeyManager(
         PluginLogger.Settings.info("REFRESH BUTTON CLICKED - refreshApiKeys() called (forceRefresh: $forceRefresh)")
         PluginLogger.Settings.info("========================================")
 
-        loadApiKeysInternal(forceRefresh)
+        loadApiKeysAsync(forceRefresh)
     }
 
-    private fun loadApiKeysInternal(forceRefresh: Boolean) {
+    /**
+     * Loads API keys asynchronously on a background thread.
+     * Updates the table model on EDT after fetching.
+     */
+    private fun loadApiKeysAsync(forceRefresh: Boolean) {
         if (!settingsService.isConfigured()) {
             PluginLogger.Settings.debug("Not configured, clearing API keys table and cache")
             apiKeyTableModel.setApiKeys(emptyList())
@@ -185,61 +204,104 @@ class ApiKeyManager(
         }
 
         // Check cache first (unless force refresh)
-        if (!forceRefresh) {
-            val now = System.currentTimeMillis()
-            val cacheAge = now - cacheTimestamp
-            val isCacheValid = cachedApiKeys != null && cacheAge < CACHE_DURATION_MS
+        if (!forceRefresh && useCachedApiKeysIfValid()) {
+            return
+        }
 
-            if (isCacheValid) {
-                PluginLogger.Settings.debug("Using cached API keys (${cachedApiKeys?.size} keys, age: ${cacheAge}ms)")
-                apiKeyTableModel.setApiKeys(cachedApiKeys!!)
-                return
-            } else if (cachedApiKeys != null) {
-                PluginLogger.Settings.debug(
-                    "Cache expired (age: ${cacheAge}ms > ${CACHE_DURATION_MS}ms), fetching fresh data"
-                )
-            }
-        } else {
+        if (forceRefresh) {
             PluginLogger.Settings.debug("Force refresh requested, bypassing cache")
         }
 
-        // Fetch from API
-        runBlocking {
-            try {
-                val result = openRouterService.getApiKeysList(settingsService.getProvisioningKey())
-                when (result) {
-                    is ApiResult.Success -> {
-                        val apiKeys = result.data.data
-                        PluginLogger.Settings.info("Loaded ${apiKeys.size} API keys from OpenRouter")
+        // Fetch from API on background thread
+        coroutineScope.launch(Dispatchers.IO) {
+            fetchAndUpdateApiKeys()
+        }
+    }
 
-                        // Update cache
-                        cachedApiKeys = apiKeys
-                        cacheTimestamp = System.currentTimeMillis()
-                        PluginLogger.Settings.debug("Updated API keys cache (${apiKeys.size} keys)")
+    /**
+     * Checks if cache is valid and uses it if so.
+     * @return true if cache was used, false if fetch is needed
+     */
+    private fun useCachedApiKeysIfValid(): Boolean {
+        val now = System.currentTimeMillis()
+        val cacheAge = now - cacheTimestamp
+        val isCacheValid = cachedApiKeys != null && cacheAge < CACHE_DURATION_MS
 
-                        apiKeyTableModel.setApiKeys(apiKeys)
-                        intellijKeyManager.ensureIntellijApiKeyExists(apiKeys)
-                    }
-                    is ApiResult.Error -> {
-                        PluginLogger.Settings.warn("Failed to load API keys: ${result.message}")
-                        apiKeyTableModel.setApiKeys(emptyList())
-                        clearCache()
-                    }
+        if (isCacheValid) {
+            PluginLogger.Settings.debug("Using cached API keys (${cachedApiKeys?.size} keys, age: ${cacheAge}ms)")
+            apiKeyTableModel.setApiKeys(cachedApiKeys!!)
+            return true
+        } else if (cachedApiKeys != null) {
+            PluginLogger.Settings.debug(
+                "Cache expired (age: ${cacheAge}ms > ${CACHE_DURATION_MS}ms), fetching fresh data"
+            )
+        }
+        return false
+    }
+
+    /**
+     * Fetches API keys from OpenRouter and updates the UI.
+     * Must be called from a background thread.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun fetchAndUpdateApiKeys() {
+        try {
+            val result = openRouterService.getApiKeysList(settingsService.getProvisioningKey())
+            ApplicationManager.getApplication().invokeLater({
+                handleApiKeysResult(result)
+            }, ModalityState.any())
+        } catch (e: IllegalStateException) {
+            PluginLogger.Settings.error("Invalid state while refreshing API keys: ${e.message}", e)
+            clearApiKeysOnEdt()
+        } catch (e: IOException) {
+            PluginLogger.Settings.error("Network error while refreshing API keys: ${e.message}", e)
+            clearApiKeysOnEdt()
+        } catch (expectedError: Exception) {
+            PluginLogger.Settings.error("Failed to refresh API keys: ${expectedError.message}", expectedError)
+            clearApiKeysOnEdt()
+        }
+    }
+
+    /**
+     * Handles the result of fetching API keys.
+     * Must be called on EDT.
+     */
+    private fun handleApiKeysResult(result: ApiResult<*>) {
+        when (result) {
+            is ApiResult.Success<*> -> {
+                @Suppress("UNCHECKED_CAST")
+                val apiKeys = (result.data as? org.zhavoronkov.openrouter.models.ApiKeysListResponse)?.data
+                    ?: emptyList()
+                PluginLogger.Settings.info("Loaded ${apiKeys.size} API keys from OpenRouter")
+
+                // Update cache
+                cachedApiKeys = apiKeys
+                cacheTimestamp = System.currentTimeMillis()
+                PluginLogger.Settings.debug("Updated API keys cache (${apiKeys.size} keys)")
+
+                apiKeyTableModel.setApiKeys(apiKeys)
+
+                // Ensure IntelliJ API key exists (runs async)
+                coroutineScope.launch(Dispatchers.IO) {
+                    intellijKeyManager.ensureIntellijApiKeyExists(apiKeys)
                 }
-            } catch (e: IllegalStateException) {
-                PluginLogger.Settings.error("Invalid state while refreshing API keys: ${e.message}", e)
-                apiKeyTableModel.setApiKeys(emptyList())
-                clearCache()
-            } catch (e: IOException) {
-                PluginLogger.Settings.error("Network error while refreshing API keys: ${e.message}", e)
-                apiKeyTableModel.setApiKeys(emptyList())
-                clearCache()
-            } catch (expectedError: Exception) {
-                PluginLogger.Settings.error("Failed to refresh API keys: ${expectedError.message}", expectedError)
+            }
+            is ApiResult.Error -> {
+                PluginLogger.Settings.warn("Failed to load API keys: ${result.message}")
                 apiKeyTableModel.setApiKeys(emptyList())
                 clearCache()
             }
         }
+    }
+
+    /**
+     * Clears API keys table on EDT.
+     */
+    private fun clearApiKeysOnEdt() {
+        ApplicationManager.getApplication().invokeLater({
+            apiKeyTableModel.setApiKeys(emptyList())
+            clearCache()
+        }, ModalityState.any())
     }
 
     fun clearCache() {
@@ -251,8 +313,6 @@ class ApiKeyManager(
     fun loadApiKeysWithoutAutoCreate() {
         PluginLogger.Settings.debug("Loading API keys without auto-creation (will use cache if available)")
         // Use cached data if available (don't force refresh)
-        loadApiKeysInternal(forceRefresh = false)
+        loadApiKeysAsync(forceRefresh = false)
     }
-
-    fun getIntellijKeyManager(): IntellijApiKeyManager = intellijKeyManager
 }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/settings/IntellijApiKeyManager.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/settings/IntellijApiKeyManager.kt
@@ -1,8 +1,13 @@
 package org.zhavoronkov.openrouter.settings
 
 import com.google.gson.JsonSyntaxException
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import org.zhavoronkov.openrouter.models.ApiKeyInfo
 import org.zhavoronkov.openrouter.models.ApiResult
 import org.zhavoronkov.openrouter.services.OpenRouterService
@@ -12,91 +17,143 @@ import org.zhavoronkov.openrouter.utils.PluginLogger
 import java.io.IOException
 
 /**
- * Manages the IntelliJ IDEA Plugin API key lifecycle
+ * Manages the IntelliJ IDEA Plugin API key lifecycle.
+ *
+ * All network operations are performed on background threads using coroutines
+ * to avoid EDT (Event Dispatch Thread) violations.
  */
 @Suppress("TooManyFunctions")
 class IntellijApiKeyManager(
     private val settingsService: OpenRouterSettingsService,
     private val openRouterService: OpenRouterService
-) {
+) : Disposable {
+
+    // Coroutine scope for background operations - uses IO dispatcher to avoid EDT violations
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     companion object {
         private const val INTELLIJ_API_KEY_NAME = "IntelliJ IDEA Plugin"
-    }
 
-    private var isCreatingApiKey = false
+        // Singleton flag to prevent concurrent API key creation across all instances
+        @Volatile
+        private var isCreatingApiKey = false
+
+        // Lock object for synchronization
+        private val creationLock = Any()
+    }
 
     fun ensureIntellijApiKeyExists(currentApiKeys: List<ApiKeyInfo>) {
-        val storedApiKey = settingsService.getApiKey()
-        val existingIntellijApiKey = currentApiKeys.find { it.name == INTELLIJ_API_KEY_NAME }
+        // Use synchronized block to prevent concurrent key operations
+        synchronized(creationLock) {
+            if (isCreatingApiKey) {
+                PluginLogger.Settings.debug("Already creating API key, skipping ensureIntellijApiKeyExists")
+                return
+            }
 
-        PluginLogger.Settings.debug(
-            "ensureIntellijApiKeyExists: storedApiKey.length=${storedApiKey.length}, " +
-                "storedApiKey.isEmpty=${storedApiKey.isEmpty()}"
-        )
-        PluginLogger.Settings.debug(
-            "ensureIntellijApiKeyExists: existingIntellijApiKey=${existingIntellijApiKey?.name ?: "null"}"
-        )
+            val storedApiKey = settingsService.getApiKey()
+            // Find ALL keys with the IntelliJ name, not just the first one
+            val existingIntellijApiKeys = currentApiKeys.filter { it.name == INTELLIJ_API_KEY_NAME }
 
-        val storedKeyMatchesRemote = validateStoredKeyMatchesRemote(existingIntellijApiKey, storedApiKey)
+            PluginLogger.Settings.debug(
+                "ensureIntellijApiKeyExists: storedApiKey.length=${storedApiKey.length}, " +
+                    "storedApiKey.isEmpty=${storedApiKey.isEmpty()}"
+            )
+            PluginLogger.Settings.debug(
+                "ensureIntellijApiKeyExists: found ${existingIntellijApiKeys.size} IntelliJ API key(s)"
+            )
 
-        if (existingIntellijApiKey != null && storedApiKey.isNotEmpty() && storedKeyMatchesRemote) {
-            PluginLogger.Settings.debug("IntelliJ API key exists and stored key matches remote - no action needed")
-            return
+            // Check if stored key matches ANY of the existing keys
+            val matchingKey = findMatchingKey(existingIntellijApiKeys, storedApiKey)
+
+            if (matchingKey != null && storedApiKey.isNotEmpty()) {
+                // We have a valid key that matches - check if there are duplicates to clean up
+                val duplicateCount = existingIntellijApiKeys.size - 1
+                if (duplicateCount > 0) {
+                    PluginLogger.Settings.warn(
+                        "Found $duplicateCount duplicate IntelliJ API key(s) - cleaning up"
+                    )
+                    cleanupDuplicateKeys(existingIntellijApiKeys, matchingKey)
+                } else {
+                    PluginLogger.Settings.debug(
+                        "IntelliJ API key exists and stored key matches - no action needed"
+                    )
+                }
+                return
+            }
+
+            handleApiKeyMismatchOrMissing(existingIntellijApiKeys, storedApiKey, matchingKey)
         }
-
-        handleApiKeyMismatchOrMissing(existingIntellijApiKey, storedApiKey, storedKeyMatchesRemote)
     }
 
-    private fun validateStoredKeyMatchesRemote(
-        existingIntellijApiKey: ApiKeyInfo?,
-        storedApiKey: String
-    ): Boolean {
-        // Validate that the stored API key actually matches the remote IntelliJ key
-        // The label field contains a preview of the key (e.g., "sk-or-v1-abc...xyz")
-        // We compare the prefix before "..." with the stored key's prefix
-        return if (existingIntellijApiKey != null && storedApiKey.isNotEmpty()) {
-            val keyLabel = existingIntellijApiKey.label
+    /**
+     * Find a key from the list that matches the stored API key prefix.
+     * Returns the first matching key or null if no match found.
+     */
+    @Suppress("ReturnCount")
+    private fun findMatchingKey(keys: List<ApiKeyInfo>, storedApiKey: String): ApiKeyInfo? {
+        if (storedApiKey.isEmpty()) return null
+
+        for (key in keys) {
+            val keyLabel = key.label
             // Label format is like "sk-or-v1-abc...xyz" - extract the prefix to compare
             val labelPrefix = if (keyLabel.contains("...")) {
                 keyLabel.substringBefore("...")
             } else {
-                // If no "...", use the whole label as prefix (shouldn't happen normally)
                 keyLabel
             }
             val storedKeyPrefix = storedApiKey.take(labelPrefix.length)
-            val matches = storedKeyPrefix == labelPrefix
-            PluginLogger.Settings.debug(
-                "ensureIntellijApiKeyExists: keyLabel=$keyLabel, " +
-                    "labelPrefix=$labelPrefix, storedKeyPrefix=$storedKeyPrefix, matches=$matches"
-            )
-            matches
-        } else {
-            false
+            if (storedKeyPrefix == labelPrefix) {
+                PluginLogger.Settings.debug(
+                    "findMatchingKey: found match - keyLabel=$keyLabel, storedKeyPrefix=$storedKeyPrefix"
+                )
+                return key
+            }
+        }
+
+        PluginLogger.Settings.debug("findMatchingKey: no matching key found for stored API key")
+        return null
+    }
+
+    /**
+     * Clean up duplicate keys, keeping only the matching one
+     */
+    private fun cleanupDuplicateKeys(allKeys: List<ApiKeyInfo>, keepKey: ApiKeyInfo) {
+        val keysToDelete = allKeys.filter { it.hash != keepKey.hash }
+        PluginLogger.Settings.info("Cleaning up ${keysToDelete.size} duplicate IntelliJ API key(s)")
+
+        for (key in keysToDelete) {
+            PluginLogger.Settings.debug("Deleting duplicate key: ${key.label}")
+            deleteIntellijApiKeySilently(key.hash)
         }
     }
 
     private fun handleApiKeyMismatchOrMissing(
-        existingIntellijApiKey: ApiKeyInfo?,
+        existingIntellijApiKeys: List<ApiKeyInfo>,
         storedApiKey: String,
-        storedKeyMatchesRemote: Boolean
+        matchingKey: ApiKeyInfo?
     ) {
         when {
-            existingIntellijApiKey != null && storedApiKey.isNotEmpty() && !storedKeyMatchesRemote -> {
+            // Case 1: Keys exist but none match stored key - delete all and recreate
+            existingIntellijApiKeys.isNotEmpty() && storedApiKey.isNotEmpty() && matchingKey == null -> {
+                val keyCount = existingIntellijApiKeys.size
                 PluginLogger.Settings.warn(
-                    "Stored API key does not match remote IntelliJ API key - regenerating"
+                    "Stored API key does not match any of $keyCount remote IntelliJ API key(s) - " +
+                        "deleting all and regenerating"
                 )
                 if (!isCreatingApiKey) {
                     recreateIntellijApiKeySilently()
                 }
             }
-            existingIntellijApiKey == null && !isCreatingApiKey -> {
+            // Case 2: No keys exist - create one
+            existingIntellijApiKeys.isEmpty() && !isCreatingApiKey -> {
                 PluginLogger.Settings.info("IntelliJ API key not found, creating automatically")
                 createIntellijApiKeyOnce()
             }
-            existingIntellijApiKey != null && storedApiKey.isEmpty() && !isCreatingApiKey -> {
+            // Case 3: Keys exist but no stored key - delete all and recreate
+            existingIntellijApiKeys.isNotEmpty() && storedApiKey.isEmpty() && !isCreatingApiKey -> {
                 PluginLogger.Settings.info(
-                    "IntelliJ API key exists remotely but not stored locally - regenerating silently"
+                    "IntelliJ API key(s) exist remotely but not stored locally - " +
+                        "deleting ${existingIntellijApiKeys.size} key(s) and regenerating"
                 )
                 recreateIntellijApiKeySilently()
             }
@@ -104,10 +161,16 @@ class IntellijApiKeyManager(
     }
 
     fun createIntellijApiKeyOnce() {
-        isCreatingApiKey = true
+        synchronized(creationLock) {
+            if (isCreatingApiKey) {
+                PluginLogger.Settings.debug("Already creating API key, skipping createIntellijApiKeyOnce")
+                return
+            }
+            isCreatingApiKey = true
+        }
 
-        // Use runBlocking since this is called during settings initialization
-        runBlocking {
+        // Use coroutine scope to avoid EDT violations
+        scope.launch {
             try {
                 val result = openRouterService.createApiKey(INTELLIJ_API_KEY_NAME)
                 when (result) {
@@ -140,18 +203,15 @@ class IntellijApiKeyManager(
         createIntellijApiKeyOnce()
     }
 
-    fun resetApiKeyCreationFlag() {
-        isCreatingApiKey = false
-        PluginLogger.Settings.info("Reset API key creation flag")
-    }
-
     private fun recreateIntellijApiKeySilently() {
-        if (isCreatingApiKey) {
-            PluginLogger.Settings.debug("Already creating API key, skipping silent regeneration")
-            return
+        synchronized(creationLock) {
+            if (isCreatingApiKey) {
+                PluginLogger.Settings.debug("Already creating API key, skipping silent regeneration")
+                return
+            }
+            isCreatingApiKey = true
         }
 
-        isCreatingApiKey = true
         PluginLogger.Settings.info("Starting silent regeneration of IntelliJ API key")
 
         try {
@@ -162,7 +222,7 @@ class IntellijApiKeyManager(
     }
 
     private fun deleteIntellijApiKeySilently(keyHash: String) {
-        runBlocking {
+        scope.launch {
             try {
                 PluginLogger.Settings.debug("Deleting existing remote IntelliJ API key")
                 val deleteResult = openRouterService.deleteApiKey(keyHash)
@@ -172,7 +232,7 @@ class IntellijApiKeyManager(
                             PluginLogger.Settings.error(
                                 "Failed to delete existing IntelliJ API key during silent regeneration"
                             )
-                            return@runBlocking
+                            return@launch
                         }
                         PluginLogger.Settings.debug("Successfully deleted existing remote IntelliJ API key")
                     }
@@ -180,7 +240,7 @@ class IntellijApiKeyManager(
                         PluginLogger.Settings.error(
                             "Failed to delete existing IntelliJ API key: ${deleteResult.message}"
                         )
-                        return@runBlocking
+                        return@launch
                     }
                 }
             } catch (e: IllegalStateException) {
@@ -189,9 +249,11 @@ class IntellijApiKeyManager(
                     e
                 )
             } catch (e: IOException) {
-                val errorMsg = "Network error deleting existing IntelliJ API key during silent regeneration: " +
-                    "${e.message ?: "Unknown error"}"
-                PluginLogger.Settings.error(errorMsg, e)
+                val errorMessage = e.message ?: "Unknown error"
+                PluginLogger.Settings.error(
+                    "Network error deleting existing IntelliJ API key during silent regeneration: $errorMessage",
+                    e
+                )
             } catch (e: JsonSyntaxException) {
                 PluginLogger.Settings.error(
                     "JSON parsing error deleting existing IntelliJ API key during silent regeneration: ${e.message}",
@@ -201,50 +263,57 @@ class IntellijApiKeyManager(
         }
     }
 
-    private fun createIntellijApiKeySilently() {
-        runBlocking {
-            try {
-                PluginLogger.Settings.debug("Creating new IntelliJ API key")
-                val result = openRouterService.createApiKey(INTELLIJ_API_KEY_NAME)
+    private suspend fun createIntellijApiKeySilently() {
+        try {
+            PluginLogger.Settings.debug("Creating new IntelliJ API key")
+            val result = openRouterService.createApiKey(INTELLIJ_API_KEY_NAME)
 
-                when (result) {
-                    is ApiResult.Success -> {
-                        val apiKey = result.data
-                        saveAndVerifyApiKey(apiKey.key)
-                        refreshStatusBarWidget()
-                    }
-                    is ApiResult.Error -> {
-                        PluginLogger.Settings.error(
-                            "Failed to create new IntelliJ API key during silent regeneration: ${result.message}"
-                        )
-                    }
+            when (result) {
+                is ApiResult.Success -> {
+                    val apiKey = result.data
+                    saveAndVerifyApiKey(apiKey.key)
+                    refreshStatusBarWidget()
                 }
-            } catch (e: IllegalStateException) {
-                PluginLogger.Settings.error(
-                    "Invalid state creating new IntelliJ API key during silent regeneration: ${e.message}",
-                    e
-                )
-            } catch (e: IOException) {
-                PluginLogger.Settings.error(
-                    "Network error creating new IntelliJ API key during silent regeneration: ${e.message}",
-                    e
-                )
-            } catch (e: JsonSyntaxException) {
-                PluginLogger.Settings.error(
-                    "JSON parsing error creating new IntelliJ API key during silent regeneration: ${e.message}",
-                    e
-                )
+                is ApiResult.Error -> {
+                    PluginLogger.Settings.error(
+                        "Failed to create new IntelliJ API key during silent regeneration: ${result.message}"
+                    )
+                }
             }
+        } catch (e: IllegalStateException) {
+            PluginLogger.Settings.error(
+                "Invalid state creating new IntelliJ API key during silent regeneration: ${e.message}",
+                e
+            )
+        } catch (e: IOException) {
+            PluginLogger.Settings.error(
+                "Network error creating new IntelliJ API key during silent regeneration: ${e.message}",
+                e
+            )
+        } catch (e: JsonSyntaxException) {
+            PluginLogger.Settings.error(
+                "JSON parsing error creating new IntelliJ API key during silent regeneration: ${e.message}",
+                e
+            )
         }
     }
 
     private fun manageIntellijApiKeySilently() {
-        runBlocking {
+        scope.launch {
             try {
                 val keysResult = openRouterService.getApiKeysList()
                 if (keysResult is ApiResult.Success) {
-                    val intellijKey = keysResult.data.data.find { it.name == INTELLIJ_API_KEY_NAME }
-                    intellijKey?.let { deleteIntellijApiKeySilently(it.hash) }
+                    // Find ALL keys with the IntelliJ name and delete them all
+                    val intellijKeys = keysResult.data.data.filter { it.name == INTELLIJ_API_KEY_NAME }
+                    if (intellijKeys.isNotEmpty()) {
+                        PluginLogger.Settings.info(
+                            "Deleting ${intellijKeys.size} existing IntelliJ API key(s) before creating new one"
+                        )
+                        for (key in intellijKeys) {
+                            PluginLogger.Settings.debug("Deleting key: ${key.label}")
+                            deleteIntellijApiKeyAsync(key.hash)
+                        }
+                    }
                 }
                 createIntellijApiKeySilently()
             } catch (e: IllegalStateException) {
@@ -254,6 +323,49 @@ class IntellijApiKeyManager(
             } catch (e: JsonSyntaxException) {
                 PluginLogger.Settings.error("JSON parsing error managing IntelliJ API key: ${e.message}", e)
             }
+        }
+    }
+
+    /**
+     * Deletes an API key asynchronously within a coroutine context.
+     */
+    private suspend fun deleteIntellijApiKeyAsync(keyHash: String) {
+        try {
+            PluginLogger.Settings.debug("Deleting existing remote IntelliJ API key")
+            val deleteResult = openRouterService.deleteApiKey(keyHash)
+            when (deleteResult) {
+                is ApiResult.Success -> {
+                    if (!deleteResult.data.deleted) {
+                        PluginLogger.Settings.error(
+                            "Failed to delete existing IntelliJ API key during silent regeneration"
+                        )
+                        return
+                    }
+                    PluginLogger.Settings.debug("Successfully deleted existing remote IntelliJ API key")
+                }
+                is ApiResult.Error -> {
+                    PluginLogger.Settings.error(
+                        "Failed to delete existing IntelliJ API key: ${deleteResult.message}"
+                    )
+                    return
+                }
+            }
+        } catch (e: IllegalStateException) {
+            PluginLogger.Settings.error(
+                "Invalid state deleting existing IntelliJ API key during silent regeneration: ${e.message}",
+                e
+            )
+        } catch (e: IOException) {
+            val errorMessage = e.message ?: "Unknown error"
+            PluginLogger.Settings.error(
+                "Network error deleting existing IntelliJ API key during silent regeneration: $errorMessage",
+                e
+            )
+        } catch (e: JsonSyntaxException) {
+            PluginLogger.Settings.error(
+                "JSON parsing error deleting existing IntelliJ API key during silent regeneration: ${e.message}",
+                e
+            )
         }
     }
 
@@ -282,5 +394,12 @@ class IntellijApiKeyManager(
                 statusBarWidget?.updateQuotaInfo()
             }
         }
+    }
+
+    /**
+     * Disposes of resources and cancels any pending coroutine operations.
+     */
+    override fun dispose() {
+        scope.cancel()
     }
 }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/statusbar/OpenRouterStatusBarWidget.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/statusbar/OpenRouterStatusBarWidget.kt
@@ -62,8 +62,8 @@ class OpenRouterStatusBarWidget(project: Project) : EditorBasedWidget(project), 
         const val LOGIN_MENU_TEXT = "Login to OpenRouter.ai"
         const val LOGOUT_MENU_TEXT = "Logout from OpenRouter.ai"
         const val SETTINGS_MENU_TEXT = "Settings"
-        const val DOCUMENTATION_MENU_TEXT = "View OpenRouter Documentation..."
-        const val FEEDBACK_MENU_TEXT = "View Feedback Repository..."
+        const val DOCUMENTATION_MENU_TEXT = "OpenRouter Documentation..."
+        const val FEEDBACK_MENU_TEXT = "Feedback Repository..."
 
         // Time conversion: milliseconds per second
         private const val MILLIS_PER_SECOND = 1000L

--- a/src/main/kotlin/org/zhavoronkov/openrouter/utils/PasswordSafeKeyStorage.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/utils/PasswordSafeKeyStorage.kt
@@ -4,6 +4,8 @@ import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.Credentials
 import com.intellij.credentialStore.generateServiceName
 import com.intellij.ide.passwordSafe.PasswordSafe
+import com.intellij.openapi.application.ApplicationManager
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Secure storage for API keys using IntelliJ's PasswordSafe.
@@ -17,7 +19,14 @@ import com.intellij.ide.passwordSafe.PasswordSafe
  *
  * In test environments where PasswordSafe is not available, this class falls back
  * to in-memory storage.
+ *
+ * IMPORTANT: This class implements in-memory caching to avoid EDT violations.
+ * PasswordSafe operations are slow and prohibited on EDT. The cache is:
+ * - Populated on first access (async) and on startup via preloadKeys()
+ * - Updated immediately when keys are set
+ * - Read operations return cached values instantly (safe for EDT)
  */
+@Suppress("TooManyFunctions")
 object PasswordSafeKeyStorage {
 
     private const val SERVICE_NAME = "OpenRouter IntelliJ Plugin"
@@ -26,6 +35,20 @@ object PasswordSafeKeyStorage {
 
     // In-memory fallback for test environments where PasswordSafe is not available
     private val inMemoryStorage = mutableMapOf<String, String>()
+
+    // Cached values - these are read on EDT without blocking
+    @Volatile
+    private var cachedApiKey: String? = null
+
+    @Volatile
+    private var cachedProvisioningKey: String? = null
+
+    // Flags to track if cache has been initialized
+    private val apiKeyCacheInitialized = AtomicBoolean(false)
+    private val provisioningKeyCacheInitialized = AtomicBoolean(false)
+
+    // Flag to track if preload has been triggered
+    private val preloadTriggered = AtomicBoolean(false)
 
     /**
      * Creates credential attributes for a specific key type.
@@ -36,28 +59,123 @@ object PasswordSafeKeyStorage {
     }
 
     /**
-     * Gets the API key from PasswordSafe, or from in-memory storage in test environments.
-     * @return The API key, or null if not stored
+     * Preloads keys from PasswordSafe into cache on a background thread.
+     * Should be called during plugin startup.
      */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    fun getApiKey(): String? {
-        return try {
-            val attributes = createCredentialAttributes(API_KEY)
-            PasswordSafe.instance.getPassword(attributes)
+    @Suppress("TooGenericExceptionCaught")
+    fun preloadKeys() {
+        if (!preloadTriggered.compareAndSet(false, true)) {
+            // Already triggered
+            return
+        }
+
+        try {
+            val application = ApplicationManager.getApplication()
+            if (application != null) {
+                application.executeOnPooledThread {
+                    loadApiKeyFromPasswordSafe()
+                    loadProvisioningKeyFromPasswordSafe()
+                }
+            } else {
+                // Test environment - load synchronously from in-memory storage
+                apiKeyCacheInitialized.set(true)
+                provisioningKeyCacheInitialized.set(true)
+            }
         } catch (_: Exception) {
-            // Fallback to in-memory storage for test environments
-            // Catches: IllegalStateException, NullPointerException, ExceptionInInitializerError
-            // Exception is intentionally swallowed - this is expected fallback behavior
-            inMemoryStorage[API_KEY]
+            // Test environment - load synchronously from in-memory storage
+            apiKeyCacheInitialized.set(true)
+            provisioningKeyCacheInitialized.set(true)
         }
     }
 
     /**
-     * Stores the API key in PasswordSafe, or in-memory storage in test environments.
-     * @param apiKey The API key to store. If blank, removes the stored key.
+     * Loads API key from PasswordSafe into cache.
+     * This is a blocking operation and should NOT be called on EDT.
      */
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun loadApiKeyFromPasswordSafe() {
+        try {
+            val attributes = createCredentialAttributes(API_KEY)
+            cachedApiKey = PasswordSafe.instance.getPassword(attributes)
+            apiKeyCacheInitialized.set(true)
+        } catch (_: Exception) {
+            // Fallback to in-memory storage for test environments
+            cachedApiKey = inMemoryStorage[API_KEY]
+            apiKeyCacheInitialized.set(true)
+        }
+    }
+
+    /**
+     * Loads provisioning key from PasswordSafe into cache.
+     * This is a blocking operation and should NOT be called on EDT.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun loadProvisioningKeyFromPasswordSafe() {
+        try {
+            val attributes = createCredentialAttributes(PROVISIONING_KEY)
+            cachedProvisioningKey = PasswordSafe.instance.getPassword(attributes)
+            provisioningKeyCacheInitialized.set(true)
+        } catch (_: Exception) {
+            // Fallback to in-memory storage for test environments
+            cachedProvisioningKey = inMemoryStorage[PROVISIONING_KEY]
+            provisioningKeyCacheInitialized.set(true)
+        }
+    }
+
+    /**
+     * Gets the API key from cache (safe for EDT).
+     *
+     * If cache is not initialized, returns null and triggers async load.
+     * For most use cases, preloadKeys() should be called on startup to ensure
+     * the cache is populated before first access.
+     *
+     * @return The API key, or null if not stored or not yet loaded
+     */
+    fun getApiKey(): String? {
+        // Return cached value immediately (safe for EDT)
+        if (apiKeyCacheInitialized.get()) {
+            return cachedApiKey
+        }
+
+        // Cache not initialized - trigger async load and return in-memory fallback
+        triggerAsyncPreload()
+        return inMemoryStorage[API_KEY]
+    }
+
+    /**
+     * Stores the API key in PasswordSafe (async) and updates cache immediately.
+     * @param apiKey The API key to store. If blank, removes the stored key.
+     */
+    @Suppress("TooGenericExceptionCaught")
     fun setApiKey(apiKey: String) {
+        // Update cache immediately (safe for EDT)
+        cachedApiKey = apiKey.ifBlank { null }
+        apiKeyCacheInitialized.set(true)
+
+        // Also update in-memory storage for consistency
+        if (apiKey.isBlank()) {
+            inMemoryStorage.remove(API_KEY)
+        } else {
+            inMemoryStorage[API_KEY] = apiKey
+        }
+
+        // Write to PasswordSafe asynchronously (skip in test environments)
+        try {
+            val application = ApplicationManager.getApplication()
+            application?.executeOnPooledThread {
+                writeApiKeyToPasswordSafe(apiKey)
+            }
+        } catch (_: Exception) {
+            // Test environment - skip PasswordSafe write
+        }
+    }
+
+    /**
+     * Writes API key to PasswordSafe.
+     * This is a blocking operation and should NOT be called on EDT.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun writeApiKeyToPasswordSafe(apiKey: String) {
         try {
             val attributes = createCredentialAttributes(API_KEY)
             if (apiKey.isBlank()) {
@@ -66,38 +184,64 @@ object PasswordSafeKeyStorage {
                 PasswordSafe.instance.set(attributes, Credentials("", apiKey))
             }
         } catch (_: Exception) {
-            // Fallback to in-memory storage for test environments
-            // Exception is intentionally swallowed - this is expected fallback behavior
-            if (apiKey.isBlank()) {
-                inMemoryStorage.remove(API_KEY)
-            } else {
-                inMemoryStorage[API_KEY] = apiKey
-            }
+            // Silently fail - cache and in-memory storage are already updated
         }
     }
 
     /**
-     * Gets the provisioning key from PasswordSafe, or from in-memory storage in test environments.
-     * @return The provisioning key, or null if not stored
+     * Gets the provisioning key from cache (safe for EDT).
+     *
+     * If cache is not initialized, returns null and triggers async load.
+     * For most use cases, preloadKeys() should be called on startup to ensure
+     * the cache is populated before first access.
+     *
+     * @return The provisioning key, or null if not stored or not yet loaded
      */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     fun getProvisioningKey(): String? {
-        return try {
-            val attributes = createCredentialAttributes(PROVISIONING_KEY)
-            PasswordSafe.instance.getPassword(attributes)
-        } catch (_: Exception) {
-            // Fallback to in-memory storage for test environments
-            // Exception is intentionally swallowed - this is expected fallback behavior
-            inMemoryStorage[PROVISIONING_KEY]
+        // Return cached value immediately (safe for EDT)
+        if (provisioningKeyCacheInitialized.get()) {
+            return cachedProvisioningKey
         }
+
+        // Cache not initialized - trigger async load and return in-memory fallback
+        triggerAsyncPreload()
+        return inMemoryStorage[PROVISIONING_KEY]
     }
 
     /**
-     * Stores the provisioning key in PasswordSafe, or in-memory storage in test environments.
+     * Stores the provisioning key in PasswordSafe (async) and updates cache immediately.
      * @param provisioningKey The provisioning key to store. If blank, removes the stored key.
      */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught")
     fun setProvisioningKey(provisioningKey: String) {
+        // Update cache immediately (safe for EDT)
+        cachedProvisioningKey = provisioningKey.ifBlank { null }
+        provisioningKeyCacheInitialized.set(true)
+
+        // Also update in-memory storage for consistency
+        if (provisioningKey.isBlank()) {
+            inMemoryStorage.remove(PROVISIONING_KEY)
+        } else {
+            inMemoryStorage[PROVISIONING_KEY] = provisioningKey
+        }
+
+        // Write to PasswordSafe asynchronously (skip in test environments)
+        try {
+            val application = ApplicationManager.getApplication()
+            application?.executeOnPooledThread {
+                writeProvisioningKeyToPasswordSafe(provisioningKey)
+            }
+        } catch (_: Exception) {
+            // Test environment - skip PasswordSafe write
+        }
+    }
+
+    /**
+     * Writes provisioning key to PasswordSafe.
+     * This is a blocking operation and should NOT be called on EDT.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun writeProvisioningKeyToPasswordSafe(provisioningKey: String) {
         try {
             val attributes = createCredentialAttributes(PROVISIONING_KEY)
             if (provisioningKey.isBlank()) {
@@ -106,22 +250,35 @@ object PasswordSafeKeyStorage {
                 PasswordSafe.instance.set(attributes, Credentials("", provisioningKey))
             }
         } catch (_: Exception) {
-            // Fallback to in-memory storage for test environments
-            // Exception is intentionally swallowed - this is expected fallback behavior
-            if (provisioningKey.isBlank()) {
-                inMemoryStorage.remove(PROVISIONING_KEY)
-            } else {
-                inMemoryStorage[PROVISIONING_KEY] = provisioningKey
-            }
+            // Silently fail - cache and in-memory storage are already updated
         }
     }
 
     /**
-     * Clears all stored keys from PasswordSafe.
+     * Triggers async preload if not already triggered.
+     */
+    private fun triggerAsyncPreload() {
+        preloadKeys()
+    }
+
+    /**
+     * Clears all stored keys from PasswordSafe and cache.
      * Used for logout functionality.
      */
     fun clearAll() {
         setApiKey("")
         setProvisioningKey("")
+    }
+
+    /**
+     * Resets the cache state. For testing purposes only.
+     */
+    internal fun resetCacheForTesting() {
+        cachedApiKey = null
+        cachedProvisioningKey = null
+        apiKeyCacheInitialized.set(false)
+        provisioningKeyCacheInitialized.set(false)
+        preloadTriggered.set(false)
+        inMemoryStorage.clear()
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/openrouter/settings/IntellijApiKeyManagerTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/settings/IntellijApiKeyManagerTest.kt
@@ -12,26 +12,19 @@ import org.zhavoronkov.openrouter.models.ApiKeyInfo
 /**
  * Tests for IntellijApiKeyManager, specifically the ensureIntellijApiKeyExists logic
  * that validates stored API keys match remote keys and handles stale key scenarios.
- */
-/**
- * Tests for IntellijApiKeyManager, specifically the ensureIntellijApiKeyExists logic
- * that validates stored API keys match remote keys and handles stale key scenarios.
  *
  * These tests verify the key matching logic that determines:
  * 1. Whether a stored API key matches a remote key (by comparing prefixes)
  * 2. Whether a key needs to be regenerated (stale key detection)
  * 3. Various edge cases in key prefix extraction
+ * 4. Multiple keys with same name (duplicate bug scenario)
+ * 5. Duplicate cleanup logic
  */
 @DisplayName("IntellijApiKeyManager Tests")
 class IntellijApiKeyManagerTest {
 
     companion object {
         const val INTELLIJ_API_KEY_NAME = "IntelliJ IDEA Plugin"
-
-        // Sample API keys for testing
-        const val VALID_API_KEY = "sk-or-v1-abc123def456789012345678901234567890abcdef123456789012345678901234"
-        const val STALE_API_KEY = "sk-or-v1-old999stale888key777that666should555be444replaced333222111000xyz"
-        const val NEW_API_KEY = "sk-or-v1-new123fresh456key789that012should345be678used901234567890abcdef"
     }
 
     @Nested
@@ -41,64 +34,44 @@ class IntellijApiKeyManagerTest {
         @Test
         @DisplayName("Should detect matching key when stored key prefix matches remote label")
         fun testMatchingKeyDetection() {
-            // Given: Remote key with label "sk-or-v1-abc...xyz"
             val remoteKeyLabel = "sk-or-v1-abc...xyz"
-
-            // And: Stored key starts with "sk-or-v1-abc"
             val storedKey = "sk-or-v1-abc123def456789012345678901234567890abcdef123456789012345678901234"
 
-            // When: We check if the keys match using the same logic as ensureIntellijApiKeyExists
             val matches = checkKeyMatches(remoteKeyLabel, storedKey)
 
-            // Then: Keys should match
             assertTrue(matches, "Stored key prefix should match remote label prefix")
         }
 
         @Test
         @DisplayName("Should detect stale key when stored key prefix does NOT match remote label")
         fun testStaleKeyDetection() {
-            // Given: Remote key with label "sk-or-v1-new...xyz"
             val remoteKeyLabel = "sk-or-v1-new...xyz"
-
-            // And: Stored key starts with "sk-or-v1-old" (different prefix!)
             val storedKey = "sk-or-v1-old999stale888key777that666should555be444replaced333222111000xyz"
 
-            // When: We check if the keys match
             val matches = checkKeyMatches(remoteKeyLabel, storedKey)
 
-            // Then: Keys should NOT match (stale key detected)
             assertFalse(matches, "Stale key should not match remote label")
         }
 
         @Test
         @DisplayName("Should handle label without ellipsis")
         fun testLabelWithoutEllipsis() {
-            // Given: Remote key with label that has no "..." (edge case)
             val remoteKeyLabel = "sk-or-v1-test"
-
-            // And: Stored key matches the full label
             val storedKey = "sk-or-v1-test123456789012345678901234567890abcdef123456789012345678901234"
 
-            // When: We check if the keys match
             val matches = checkKeyMatches(remoteKeyLabel, storedKey)
 
-            // Then: Keys should match
             assertTrue(matches, "Stored key should match label without ellipsis")
         }
 
         @Test
         @DisplayName("Should detect mismatch with label without ellipsis")
         fun testMismatchWithoutEllipsis() {
-            // Given: Remote key with label that has no "..."
             val remoteKeyLabel = "sk-or-v1-new"
-
-            // And: Stored key does NOT match
             val storedKey = "sk-or-v1-old999stale888key777that666should555be444replaced333222111000xyz"
 
-            // When: We check if the keys match
             val matches = checkKeyMatches(remoteKeyLabel, storedKey)
 
-            // Then: Keys should NOT match
             assertFalse(matches, "Stored key should not match different label")
         }
     }
@@ -110,33 +83,27 @@ class IntellijApiKeyManagerTest {
         @Test
         @DisplayName("Should identify when no IntelliJ key exists remotely")
         fun testNoIntellijKeyExists() {
-            // Given: No IntelliJ API key exists remotely
             val otherKeys = listOf(
                 createApiKeyInfo(name = "other-key-1", label = "sk-or-v1-other1...xyz"),
                 createApiKeyInfo(name = "other-key-2", label = "sk-or-v1-other2...xyz")
             )
 
-            // When: We look for the IntelliJ key
             val intellijKey = otherKeys.find { it.name == INTELLIJ_API_KEY_NAME }
 
-            // Then: No IntelliJ key should be found
             assertNull(intellijKey, "No IntelliJ key should exist in the list")
         }
 
         @Test
         @DisplayName("Should identify when IntelliJ key exists remotely")
         fun testIntellijKeyExists() {
-            // Given: IntelliJ API key exists remotely
             val keys = listOf(
                 createApiKeyInfo(name = "other-key-1", label = "sk-or-v1-other1...xyz"),
                 createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-intellij...xyz"),
                 createApiKeyInfo(name = "other-key-2", label = "sk-or-v1-other2...xyz")
             )
 
-            // When: We look for the IntelliJ key
             val intellijKey = keys.find { it.name == INTELLIJ_API_KEY_NAME }
 
-            // Then: IntelliJ key should be found
             assertEquals(INTELLIJ_API_KEY_NAME, intellijKey?.name, "IntelliJ key should be found")
             assertEquals("sk-or-v1-intellij...xyz", intellijKey?.label, "IntelliJ key label should match")
         }
@@ -144,20 +111,12 @@ class IntellijApiKeyManagerTest {
         @Test
         @DisplayName("Should identify scenario: key exists remotely but not stored locally")
         fun testKeyExistsRemotelyButNotLocally() {
-            // Given: IntelliJ API key exists remotely
-            val remoteKey = createApiKeyInfo(
-                name = INTELLIJ_API_KEY_NAME,
-                label = "sk-or-v1-remote...xyz"
-            )
-
-            // And: No stored API key locally
+            val remoteKey = createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-remote...xyz")
             val storedKey = ""
 
-            // When: We check the scenario
             val keyExistsRemotely = remoteKey.name == INTELLIJ_API_KEY_NAME
             val keyStoredLocally = storedKey.isNotEmpty()
 
-            // Then: Should identify need to regenerate
             assertTrue(keyExistsRemotely, "Key should exist remotely")
             assertFalse(keyStoredLocally, "Key should not be stored locally")
         }
@@ -165,21 +124,13 @@ class IntellijApiKeyManagerTest {
         @Test
         @DisplayName("Should identify scenario: key exists and matches")
         fun testKeyExistsAndMatches() {
-            // Given: IntelliJ API key exists remotely with label "sk-or-v1-abc...xyz"
-            val remoteKey = createApiKeyInfo(
-                name = INTELLIJ_API_KEY_NAME,
-                label = "sk-or-v1-abc...xyz"
-            )
-
-            // And: Stored key matches (starts with "sk-or-v1-abc")
+            val remoteKey = createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abc...xyz")
             val storedKey = "sk-or-v1-abc123def456789012345678901234567890abcdef123456789012345678901234"
 
-            // When: We check the scenario
             val keyExistsRemotely = remoteKey.name == INTELLIJ_API_KEY_NAME
             val keyStoredLocally = storedKey.isNotEmpty()
             val keysMatch = checkKeyMatches(remoteKey.label, storedKey)
 
-            // Then: Should identify no action needed
             assertTrue(keyExistsRemotely, "Key should exist remotely")
             assertTrue(keyStoredLocally, "Key should be stored locally")
             assertTrue(keysMatch, "Keys should match")
@@ -188,21 +139,13 @@ class IntellijApiKeyManagerTest {
         @Test
         @DisplayName("Should identify scenario: key exists but is stale")
         fun testKeyExistsButIsStale() {
-            // Given: IntelliJ API key exists remotely with label "sk-or-v1-new...xyz"
-            val remoteKey = createApiKeyInfo(
-                name = INTELLIJ_API_KEY_NAME,
-                label = "sk-or-v1-new...xyz"
-            )
-
-            // And: Stored key is stale (starts with "sk-or-v1-old")
+            val remoteKey = createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-new...xyz")
             val storedKey = "sk-or-v1-old999stale888key777that666should555be444replaced333222111000xyz"
 
-            // When: We check the scenario
             val keyExistsRemotely = remoteKey.name == INTELLIJ_API_KEY_NAME
             val keyStoredLocally = storedKey.isNotEmpty()
             val keysMatch = checkKeyMatches(remoteKey.label, storedKey)
 
-            // Then: Should identify need to regenerate due to stale key
             assertTrue(keyExistsRemotely, "Key should exist remotely")
             assertTrue(keyStoredLocally, "Key should be stored locally")
             assertFalse(keysMatch, "Keys should NOT match (stale)")
@@ -270,31 +213,375 @@ class IntellijApiKeyManagerTest {
         }
     }
 
+    @Nested
+    @DisplayName("Multiple Keys With Same Name Tests")
+    inner class MultipleKeysTests {
+
+        @Test
+        @DisplayName("Should find matching key among multiple keys with same name")
+        fun testFindMatchingKeyAmongDuplicates() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-first...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-second...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-third...333", hash = "hash3"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-match...444", hash = "hash4"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-fifth...555", hash = "hash5")
+            )
+
+            val storedKey = "sk-or-v1-match123456789012345678901234567890abcdef123456789012345678"
+
+            val intellijKeys = keys.filter { it.name == INTELLIJ_API_KEY_NAME }
+            val matchingKey = findMatchingKey(intellijKeys, storedKey)
+
+            assertEquals(5, intellijKeys.size, "Should find all 5 duplicate keys")
+            assertEquals("hash4", matchingKey?.hash, "Should find the matching key (4th one)")
+            assertEquals("sk-or-v1-match...444", matchingKey?.label, "Matching key label should be correct")
+        }
+
+        @Test
+        @DisplayName("Should return null when no key matches among duplicates")
+        fun testNoMatchingKeyAmongDuplicates() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-first...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-second...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-third...333", hash = "hash3")
+            )
+
+            val storedKey = "sk-or-v1-nomatch9999999999999999999999999999999999999999999999999999"
+
+            val intellijKeys = keys.filter { it.name == INTELLIJ_API_KEY_NAME }
+            val matchingKey = findMatchingKey(intellijKeys, storedKey)
+
+            assertEquals(3, intellijKeys.size, "Should find all 3 duplicate keys")
+            assertNull(matchingKey, "No key should match the stored key")
+        }
+
+        @Test
+        @DisplayName("Should find first matching key when multiple could match")
+        fun testFirstMatchingKeySelected() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abc...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abc...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abc...333", hash = "hash3")
+            )
+
+            val storedKey = "sk-or-v1-abc123456789012345678901234567890abcdef123456789012345678"
+
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            assertEquals("hash1", matchingKey?.hash, "Should return first matching key")
+        }
+
+        @Test
+        @DisplayName("Should handle empty stored key with multiple remote keys")
+        fun testEmptyStoredKeyWithDuplicates() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-first...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-second...222", hash = "hash2")
+            )
+
+            val storedKey = ""
+
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            assertNull(matchingKey, "Empty stored key should not match any remote key")
+        }
+
+        @Test
+        @DisplayName("Should handle single key correctly (no duplicates)")
+        fun testSingleKeyNoDuplicates() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-only...999", hash = "hash1")
+            )
+
+            val storedKey = "sk-or-v1-only123456789012345678901234567890abcdef123456789012345678"
+
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            assertEquals("hash1", matchingKey?.hash, "Should find the only key")
+        }
+    }
+
+    @Nested
+    @DisplayName("Duplicate Cleanup Logic Tests")
+    inner class DuplicateCleanupTests {
+
+        @Test
+        @DisplayName("Should identify all duplicate keys to delete")
+        fun testIdentifyDuplicatesToDelete() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-dup1...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-dup2...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-keep...333", hash = "hash3"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-dup4...444", hash = "hash4"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-dup5...555", hash = "hash5")
+            )
+
+            val storedKey = "sk-or-v1-keep123456789012345678901234567890abcdef123456789012345678"
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            val keysToDelete = keys.filter { it.hash != matchingKey?.hash }
+
+            assertEquals(4, keysToDelete.size, "Should identify 4 duplicate keys to delete")
+            assertTrue(keysToDelete.all { it.hash != "hash3" }, "Matching key should not be in delete list")
+            assertTrue(keysToDelete.any { it.hash == "hash1" }, "hash1 should be in delete list")
+            assertTrue(keysToDelete.any { it.hash == "hash2" }, "hash2 should be in delete list")
+            assertTrue(keysToDelete.any { it.hash == "hash4" }, "hash4 should be in delete list")
+            assertTrue(keysToDelete.any { it.hash == "hash5" }, "hash5 should be in delete list")
+        }
+
+        @Test
+        @DisplayName("Should identify all keys to delete when none match")
+        fun testAllKeysToDeleteWhenNoMatch() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-old1...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-old2...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-old3...333", hash = "hash3")
+            )
+
+            val storedKey = "sk-or-v1-different123456789012345678901234567890abcdef1234567890123"
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            val keysToDelete = if (matchingKey == null) keys else keys.filter { it.hash != matchingKey.hash }
+
+            assertEquals(3, keysToDelete.size, "All 3 keys should be deleted when none match")
+        }
+
+        @Test
+        @DisplayName("Should not delete any keys when single key matches")
+        fun testNoDeleteWhenSingleKeyMatches() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-single...111", hash = "hash1")
+            )
+
+            val storedKey = "sk-or-v1-single123456789012345678901234567890abcdef123456789012345678"
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            val keysToDelete = keys.filter { it.hash != matchingKey?.hash }
+
+            assertEquals(0, keysToDelete.size, "No keys should be deleted when single key matches")
+        }
+
+        @Test
+        @DisplayName("Should count duplicates correctly for 12 keys scenario")
+        fun testDuplicateCount() {
+            val keys = (1..12).map { i ->
+                createApiKeyInfo(
+                    name = INTELLIJ_API_KEY_NAME,
+                    label = "sk-or-v1-dup$i...${i.toString().padStart(3, '0')}",
+                    hash = "hash$i"
+                )
+            }
+
+            val storedKey = "sk-or-v1-dup7123456789012345678901234567890abcdef1234567890123456789"
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            val duplicateCount = keys.size - 1
+
+            assertEquals(11, duplicateCount, "Should count 11 duplicates (12 total - 1 matching)")
+            assertEquals("hash7", matchingKey?.hash, "Should find hash7 as matching")
+        }
+    }
+
+    @Nested
+    @DisplayName("Filter vs Find Behavior Tests")
+    inner class FilterVsFindTests {
+
+        @Test
+        @DisplayName("filter() should return all matching keys, not just first")
+        fun testFilterReturnsAll() {
+            val keys = listOf(
+                createApiKeyInfo(name = "other-key", label = "sk-or-v1-other...000", hash = "hash0"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-ij1...111", hash = "hash1"),
+                createApiKeyInfo(name = "another-key", label = "sk-or-v1-another...aaa", hash = "hashA"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-ij2...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-ij3...333", hash = "hash3")
+            )
+
+            val intellijKeys = keys.filter { it.name == INTELLIJ_API_KEY_NAME }
+
+            assertEquals(3, intellijKeys.size, "filter() should return all 3 IntelliJ keys")
+            assertTrue(intellijKeys.all { it.name == INTELLIJ_API_KEY_NAME }, "All should be IntelliJ keys")
+        }
+
+        @Test
+        @DisplayName("find() would only return first key (showing why filter is needed)")
+        fun testFindReturnsOnlyFirst() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-first...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-second...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-third...333", hash = "hash3")
+            )
+
+            val firstKey = keys.find { it.name == INTELLIJ_API_KEY_NAME }
+
+            assertEquals("hash1", firstKey?.hash, "find() only returns first key")
+        }
+
+        @Test
+        @DisplayName("Stored key might match 3rd key but find() would check 1st key only - bug scenario")
+        fun testBugScenarioWithFind() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-first...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-second...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-match...333", hash = "hash3")
+            )
+
+            val storedKey = "sk-or-v1-match123456789012345678901234567890abcdef123456789012345678"
+
+            // OLD buggy approach using find()
+            val firstKey = keys.find { it.name == INTELLIJ_API_KEY_NAME }
+            val oldBuggyMatch = checkKeyMatches(firstKey!!.label, storedKey)
+
+            assertFalse(oldBuggyMatch, "OLD find() approach would not find the match in 3rd key")
+
+            // NEW correct approach using filter() + findMatchingKey
+            val allKeys = keys.filter { it.name == INTELLIJ_API_KEY_NAME }
+            val newCorrectMatch = findMatchingKey(allKeys, storedKey)
+
+            assertEquals("hash3", newCorrectMatch?.hash, "NEW filter() approach finds the correct match")
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases Tests")
+    inner class EdgeCasesTests {
+
+        @Test
+        @DisplayName("Should handle empty keys list")
+        fun testEmptyKeysList() {
+            val keys = emptyList<ApiKeyInfo>()
+            val storedKey = "sk-or-v1-any123456789012345678901234567890abcdef123456789012345678"
+
+            val intellijKeys = keys.filter { it.name == INTELLIJ_API_KEY_NAME }
+            val matchingKey = findMatchingKey(intellijKeys, storedKey)
+
+            assertEquals(0, intellijKeys.size, "Should be empty")
+            assertNull(matchingKey, "No match in empty list")
+        }
+
+        @Test
+        @DisplayName("Should handle keys with very similar prefixes - first match wins")
+        fun testSimilarPrefixes() {
+            // Given: Keys with overlapping prefixes
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abc...111", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abcd...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abcde...333", hash = "hash3")
+            )
+
+            // And: Stored key starts with "sk-or-v1-abcd"
+            val storedKey = "sk-or-v1-abcd123456789012345678901234567890abcdef12345678901234567"
+
+            // When: We find matching key
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            // Then: The first key "sk-or-v1-abc..." matches because "abc" is a prefix of "abcd..."
+            // This is the expected behavior - shorter prefix matches first
+            assertEquals("hash1", matchingKey?.hash, "First matching prefix wins (abc matches abcd)")
+        }
+
+        @Test
+        @DisplayName("Should match exact prefix when order is different")
+        fun testExactPrefixMatchWithDifferentOrder() {
+            // Given: Keys with overlapping prefixes in different order (longer first)
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abcde...333", hash = "hash3"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abcd...222", hash = "hash2"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-abc...111", hash = "hash1")
+            )
+
+            // And: Stored key starts with "sk-or-v1-abcde"
+            val storedKey = "sk-or-v1-abcde23456789012345678901234567890abcdef12345678901234567"
+
+            // When: We find matching key
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            // Then: Should match hash3 (exact match with abcde)
+            assertEquals("hash3", matchingKey?.hash, "Should match the first key with matching prefix")
+        }
+
+        @Test
+        @DisplayName("Should handle key labels with different suffix lengths")
+        fun testDifferentSuffixLengths() {
+            val keys = listOf(
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-short...x", hash = "hash1"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-match...abcdefghij", hash = "hash2")
+            )
+
+            val storedKey = "sk-or-v1-match123456789012345678901234567890abcdef12345678901234567"
+
+            val matchingKey = findMatchingKey(keys, storedKey)
+
+            assertEquals("hash2", matchingKey?.hash, "Should match regardless of suffix length")
+        }
+
+        @Test
+        @DisplayName("Should handle mixed key names correctly")
+        fun testMixedKeyNames() {
+            val keys = listOf(
+                createApiKeyInfo(name = "Cline", label = "sk-or-v1-cline...111", hash = "hash-cline"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-ij1...222", hash = "hash-ij1"),
+                createApiKeyInfo(name = "Goose", label = "sk-or-v1-goose...333", hash = "hash-goose"),
+                createApiKeyInfo(name = INTELLIJ_API_KEY_NAME, label = "sk-or-v1-ij2...444", hash = "hash-ij2"),
+                createApiKeyInfo(name = "Serper", label = "sk-or-v1-serper...555", hash = "hash-serper")
+            )
+
+            val intellijKeys = keys.filter { it.name == INTELLIJ_API_KEY_NAME }
+
+            assertEquals(2, intellijKeys.size, "Should filter only IntelliJ keys")
+            assertTrue(intellijKeys.all { it.name == INTELLIJ_API_KEY_NAME })
+            assertTrue(intellijKeys.any { it.hash == "hash-ij1" })
+            assertTrue(intellijKeys.any { it.hash == "hash-ij2" })
+        }
+    }
+
+    // ==================== HELPER METHODS ====================
+
     /**
      * Helper method that replicates the key matching logic from IntellijApiKeyManager.
      * This is the same logic used in ensureIntellijApiKeyExists to determine if a stored
      * key matches the remote key.
-     *
-     * @param remoteKeyLabel The label from the remote API key (e.g., "sk-or-v1-abc...xyz")
-     * @param storedKey The full API key stored locally
-     * @return true if the stored key matches the remote key label
      */
     private fun checkKeyMatches(remoteKeyLabel: String, storedKey: String): Boolean {
         if (storedKey.isEmpty()) return false
 
-        // Extract prefix from label (before "..." if present)
         val labelPrefix = if (remoteKeyLabel.contains("...")) {
             remoteKeyLabel.substringBefore("...")
         } else {
             remoteKeyLabel
         }
 
-        // Check if stored key starts with the same prefix
         val storedKeyPrefix = storedKey.take(labelPrefix.length)
         return storedKeyPrefix == labelPrefix
     }
 
-    // Helper method to create ApiKeyInfo for testing
+    /**
+     * Helper method that replicates the findMatchingKey logic from IntellijApiKeyManager.
+     * This finds a key from the list that matches the stored API key prefix.
+     */
+    @Suppress("ReturnCount")
+    private fun findMatchingKey(keys: List<ApiKeyInfo>, storedApiKey: String): ApiKeyInfo? {
+        if (storedApiKey.isEmpty()) return null
+
+        for (key in keys) {
+            val keyLabel = key.label
+            val labelPrefix = if (keyLabel.contains("...")) {
+                keyLabel.substringBefore("...")
+            } else {
+                keyLabel
+            }
+            val storedKeyPrefix = storedApiKey.take(labelPrefix.length)
+            if (storedKeyPrefix == labelPrefix) {
+                return key
+            }
+        }
+        return null
+    }
+
+    /**
+     * Helper method to create ApiKeyInfo for testing.
+     */
     @Suppress("LongParameterList")
     private fun createApiKeyInfo(
         name: String,

--- a/src/test/kotlin/org/zhavoronkov/openrouter/utils/PasswordSafeKeyStorageTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/utils/PasswordSafeKeyStorageTest.kt
@@ -19,8 +19,9 @@ class PasswordSafeKeyStorageTest {
 
     @BeforeEach
     fun setUp() {
-        // Clear all keys before each test to ensure isolation
-        PasswordSafeKeyStorage.clearAll()
+        // Reset cache state and clear all keys before each test to ensure isolation
+        // resetCacheForTesting() clears the cache, preload flag, and in-memory storage
+        PasswordSafeKeyStorage.resetCacheForTesting()
     }
 
     @Nested


### PR DESCRIPTION
### Problem

When multiple "IntelliJ IDEA Plugin" API keys existed on OpenRouter (e.g., from previous sessions, manual creation, or edge cases), the plugin would only find the **first** key using `find()`, potentially missing the actual matching key. This could cause:
- Unnecessary key regeneration even when a valid key existed
- Duplicate keys accumulating on the account
- EDT (Event Dispatch Thread) violations when accessing PasswordSafe from UI components

### Solution

#### 1. Duplicate Key Detection & Cleanup
- Changed from `find()` to `filter()` to retrieve **all** IntelliJ API keys, not just the first one
- Added `findMatchingKey()` method that searches through all keys to find one matching the stored API key prefix
- Implemented `cleanupDuplicateKeys()` to automatically delete orphan/duplicate keys while keeping the valid matching key

#### 2. Thread Safety & EDT Compliance
- Replaced `runBlocking` with proper coroutine scopes using `Dispatchers.IO`
- Added synchronized access with `creationLock` to prevent race conditions during concurrent key creation
- Implemented in-memory caching in `PasswordSafeKeyStorage` to avoid EDT violations:
  - Getter methods now return cached values immediately (safe for EDT)
  - Setter methods update cache instantly and persist to PasswordSafe asynchronously
- Added `preloadKeys()` called on plugin startup to warm the cache

#### 3. Resource Management
- `IntellijApiKeyManager` now implements `Disposable` for proper coroutine scope cleanup
- Added proper lifecycle management for background operations

### Changes

| File | Description |
|------|-------------|
| `IntellijApiKeyManager.kt` | Major refactoring: duplicate detection, async operations, thread safety |
| `ApiKeyManager.kt` | Replaced `runBlocking` with async operations, proper EDT handling |
| `PasswordSafeKeyStorage.kt` | Added in-memory caching, async writes, startup preloading |
| `PluginLifecycleListener.kt` | Added `PasswordSafeKeyStorage.preloadKeys()` call |
| `IntellijApiKeyManagerTest.kt` | Comprehensive tests for duplicate handling and edge cases |
| `OpenRouterModels.kt` | Made `GenerationTrackingInfo` XML-serializable with mutable properties |
| `OpenRouterIcons.kt` | Fixed tool window icon size (13x13 per IntelliJ requirements) |
| `OpenRouterStatusBarWidget.kt` | Minor menu label cleanup |

### Testing

Added extensive unit tests covering:
- ✅ Finding matching key among multiple duplicates
- ✅ Cleanup logic for duplicate keys  
- ✅ Filter vs Find behavior (demonstrating the bug scenario)
- ✅ Edge cases (empty lists, similar prefixes, mixed key names)
- ✅ PasswordSafe cache reset for test isolation

### Related

Fixes issues where users with multiple "IntelliJ IDEA Plugin" keys on their OpenRouter account would experience unnecessary key regeneration or plugin instability.