### PR TITLE
Add BalanceProvider Extension Point API

### DIFF
--- a/src/main/kotlin/org/zhavoronkov/openrouter/api/BalanceData.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/api/BalanceData.kt
@@ -40,6 +40,15 @@ data class BalanceData(
     companion object {
         /** Default source identifier for OpenRouter data */
         const val SOURCE_OPENROUTER = "openrouter"
+
+        /** Percentage multiplier for converting ratios to percentages */
+        private const val PERCENTAGE_MULTIPLIER = 100.0
+
+        /** Default percentage when total credits is zero */
+        private const val DEFAULT_REMAINING_PERCENTAGE = 100.0
+
+        /** Default usage percentage when total credits is zero */
+        private const val DEFAULT_USAGE_PERCENTAGE = 0.0
     }
 
     init {
@@ -58,9 +67,9 @@ data class BalanceData(
      */
     fun remainingPercentage(): Double {
         return if (totalCredits > 0) {
-            (remainingCredits / totalCredits) * 100.0
+            (remainingCredits / totalCredits) * PERCENTAGE_MULTIPLIER
         } else {
-            100.0
+            DEFAULT_REMAINING_PERCENTAGE
         }
     }
 
@@ -71,9 +80,9 @@ data class BalanceData(
      */
     fun usagePercentage(): Double {
         return if (totalCredits > 0) {
-            (totalUsage / totalCredits) * 100.0
+            (totalUsage / totalCredits) * PERCENTAGE_MULTIPLIER
         } else {
-            0.0
+            DEFAULT_USAGE_PERCENTAGE
         }
     }
 
@@ -92,7 +101,7 @@ data class BalanceData(
      * @return Formatted string like "$12.34"
      */
     fun formattedRemaining(): String {
-        return String.format("$%.2f", remainingCredits)
+        return String.format(java.util.Locale.US, "$%.2f", remainingCredits)
     }
 
     /**
@@ -101,13 +110,13 @@ data class BalanceData(
      * @return Formatted string like "$1.23" or "N/A" if unavailable
      */
     fun formattedTodayUsage(): String {
-        return todayUsage?.let { String.format("$%.2f", it) } ?: "N/A"
+        return todayUsage?.let { String.format(java.util.Locale.US, "$%.2f", it) } ?: "N/A"
     }
 
     override fun toString(): String {
-        return "BalanceData(remaining=$${String.format("%.2f", remainingCredits)}, " +
-            "used=$${String.format("%.2f", totalUsage)}, " +
-            "total=$${String.format("%.2f", totalCredits)}, " +
+        return "BalanceData(remaining=$${String.format(java.util.Locale.US, "%.2f", remainingCredits)}, " +
+            "used=$${String.format(java.util.Locale.US, "%.2f", totalUsage)}, " +
+            "total=$${String.format(java.util.Locale.US, "%.2f", totalCredits)}, " +
             "today=${formattedTodayUsage()})"
     }
 }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/api/BalanceData.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/api/BalanceData.kt
@@ -1,0 +1,116 @@
+package org.zhavoronkov.openrouter.api
+
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Immutable balance data provided by the OpenRouter plugin.
+ *
+ * This data class contains a snapshot of the user's OpenRouter account balance,
+ * including total credits, usage, and remaining balance. All monetary values
+ * are in USD (United States Dollars).
+ *
+ * ## Thread Safety
+ * This class is immutable and safe to share across threads.
+ *
+ * ## Validation
+ * The constructor validates that:
+ * - [totalCredits] and [totalUsage] are non-negative
+ * - [timestamp] is positive (Unix milliseconds)
+ *
+ * @property totalCredits Total credits purchased/available in USD
+ * @property totalUsage Total credits used to date in USD
+ * @property remainingCredits Calculated remaining balance (totalCredits - totalUsage)
+ * @property timestamp Unix timestamp in milliseconds when this data was fetched
+ * @property todayUsage Optional usage for the current day in USD (may be null if unavailable)
+ * @property source Identifier of the data source, defaults to "openrouter"
+ *
+ * @throws IllegalArgumentException if validation fails
+ * @see BalanceProvider
+ * @since 0.6.0
+ */
+@ApiStatus.AvailableSince("0.6.0")
+data class BalanceData(
+    val totalCredits: Double,
+    val totalUsage: Double,
+    val remainingCredits: Double,
+    val timestamp: Long,
+    val todayUsage: Double? = null,
+    val source: String = SOURCE_OPENROUTER
+) {
+    companion object {
+        /** Default source identifier for OpenRouter data */
+        const val SOURCE_OPENROUTER = "openrouter"
+    }
+
+    init {
+        require(totalCredits >= 0) { "totalCredits must be non-negative, was: $totalCredits" }
+        require(totalUsage >= 0) { "totalUsage must be non-negative, was: $totalUsage" }
+        require(timestamp > 0) { "timestamp must be positive, was: $timestamp" }
+        todayUsage?.let {
+            require(it >= 0) { "todayUsage must be non-negative when provided, was: $it" }
+        }
+    }
+
+    /**
+     * Returns the remaining balance as a percentage of total credits.
+     *
+     * @return Percentage (0.0 to 100.0), or 100.0 if totalCredits is zero
+     */
+    fun remainingPercentage(): Double {
+        return if (totalCredits > 0) {
+            (remainingCredits / totalCredits) * 100.0
+        } else {
+            100.0
+        }
+    }
+
+    /**
+     * Returns the usage as a percentage of total credits.
+     *
+     * @return Percentage (0.0 to 100.0), or 0.0 if totalCredits is zero
+     */
+    fun usagePercentage(): Double {
+        return if (totalCredits > 0) {
+            (totalUsage / totalCredits) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    /**
+     * Checks if the balance is critically low (less than 10% remaining).
+     *
+     * @return true if remaining balance is less than 10% of total credits
+     */
+    fun isLowBalance(): Boolean {
+        return remainingPercentage() < LOW_BALANCE_THRESHOLD
+    }
+
+    /**
+     * Returns a formatted string representation of the remaining balance.
+     *
+     * @return Formatted string like "$12.34"
+     */
+    fun formattedRemaining(): String {
+        return String.format("$%.2f", remainingCredits)
+    }
+
+    /**
+     * Returns a formatted string representation of today's usage.
+     *
+     * @return Formatted string like "$1.23" or "N/A" if unavailable
+     */
+    fun formattedTodayUsage(): String {
+        return todayUsage?.let { String.format("$%.2f", it) } ?: "N/A"
+    }
+
+    override fun toString(): String {
+        return "BalanceData(remaining=$${String.format("%.2f", remainingCredits)}, " +
+            "used=$${String.format("%.2f", totalUsage)}, " +
+            "total=$${String.format("%.2f", totalCredits)}, " +
+            "today=${formattedTodayUsage()})"
+    }
+}
+
+/** Threshold percentage below which balance is considered low */
+private const val LOW_BALANCE_THRESHOLD = 10.0

--- a/src/main/kotlin/org/zhavoronkov/openrouter/api/BalanceProvider.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/api/BalanceProvider.kt
@@ -1,0 +1,81 @@
+package org.zhavoronkov.openrouter.api
+
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Extension point interface for receiving OpenRouter balance data.
+ *
+ * This interface allows other plugins to receive real-time balance updates from the
+ * OpenRouter plugin without needing direct access to OpenRouter's internal services.
+ *
+ * ## Security Note
+ * This extension point shares your OpenRouter balance information (credits, usage)
+ * with implementing plugins. Users can disable this feature in Settings → Tools → OpenRouter.
+ *
+ * ## Implementation Guide
+ * To receive balance updates in your plugin:
+ *
+ * 1. Add a dependency on the OpenRouter plugin in your `plugin.xml`:
+ *    ```xml
+ *    <depends>org.zhavoronkov.openrouter</depends>
+ *    ```
+ *
+ * 2. Implement this interface:
+ *    ```kotlin
+ *    class MyBalanceListener : BalanceProvider {
+ *        override fun onBalanceUpdated(data: BalanceData) {
+ *            // Handle balance update
+ *        }
+ *    }
+ *    ```
+ *
+ * 3. Register your implementation in your `plugin.xml`:
+ *    ```xml
+ *    <extensions defaultExtensionNs="org.zhavoronkov.openrouter">
+ *        <balanceProvider implementation="com.example.MyBalanceListener"/>
+ *    </extensions>
+ *    ```
+ *
+ * ## Threading
+ * Callbacks are invoked on the EDT (Event Dispatch Thread). Implementations should
+ * handle data quickly to avoid blocking the UI. For long-running operations, use
+ * background threads or coroutines.
+ *
+ * @see BalanceData
+ * @since 0.6.0
+ */
+@ApiStatus.AvailableSince("0.6.0")
+interface BalanceProvider {
+
+    /**
+     * Called when balance data is updated.
+     *
+     * This method is invoked whenever the OpenRouter plugin successfully refreshes
+     * balance information from the API. The data is immutable and validated.
+     *
+     * @param data The current balance snapshot containing credits and usage information
+     */
+    fun onBalanceUpdated(data: BalanceData)
+
+    /**
+     * Called when balance loading starts.
+     *
+     * This optional callback can be used to show loading indicators in your UI.
+     * Default implementation does nothing.
+     */
+    fun onBalanceLoading() {
+        // Default empty implementation
+    }
+
+    /**
+     * Called when balance loading fails.
+     *
+     * This optional callback is invoked when the OpenRouter plugin fails to retrieve
+     * balance data (e.g., network error, authentication failure).
+     *
+     * @param error A human-readable error message describing the failure
+     */
+    fun onBalanceError(error: String) {
+        // Default empty implementation
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/openrouter/models/OpenRouterModels.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/models/OpenRouterModels.kt
@@ -308,7 +308,9 @@ data class OpenRouterSettings(
     var proxyAutoStart: Boolean = false, // Auto-start proxy server on IDEA startup
     var proxyPort: Int = 0, // Preferred proxy server port (0 = auto-select from range)
     var proxyPortRangeStart: Int = 8880, // Start of port range for auto-selection
-    var proxyPortRangeEnd: Int = 8899 // End of port range for auto-selection
+    var proxyPortRangeEnd: Int = 8899, // End of port range for auto-selection
+    // Extension Point Settings
+    var balanceProviderEnabled: Boolean = true // Allow other plugins to receive balance data (enabled by default)
 )
 
 /**

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifier.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifier.kt
@@ -65,8 +65,8 @@ class BalanceProviderNotifier : Disposable {
             return try {
                 val app = ApplicationManager.getApplication() ?: return null
                 app.getService(BalanceProviderNotifier::class.java)
-            } catch (e: IllegalStateException) {
-                PluginLogger.Service.debug("BalanceProviderNotifier not available: ${e.message}")
+            } catch (expected: IllegalStateException) {
+                PluginLogger.Service.debug("BalanceProviderNotifier not available: ${expected.message}")
                 null
             }
         }
@@ -138,32 +138,38 @@ class BalanceProviderNotifier : Disposable {
 
     /**
      * Checks if any balance providers are registered.
+     * This method is intended for debugging and diagnostics.
      *
      * @return true if at least one provider is registered
      */
+    @Suppress("unused") // API for debugging
     fun hasProviders(): Boolean {
         return try {
             EP_NAME.hasAnyExtensions()
-        } catch (e: IllegalStateException) {
-            PluginLogger.Service.debug("Cannot check for providers: ${e.message}")
+        } catch (expected: IllegalStateException) {
+            PluginLogger.Service.debug("Cannot check for providers: ${expected.message}")
             false
         }
     }
 
     /**
      * Gets the count of registered balance providers.
+     * This method is intended for debugging and diagnostics.
      *
      * @return Number of registered providers
      */
+    @Suppress("unused") // API for debugging
     fun getProviderCount(): Int {
         return getProviders().size
     }
 
     /**
-     * Gets the list of registered provider class names (for debugging/logging).
+     * Gets the list of registered provider class names.
+     * This method is intended for debugging and diagnostics.
      *
      * @return List of provider class names
      */
+    @Suppress("unused") // API for debugging
     fun getProviderNames(): List<String> {
         return getProviders().map { it.javaClass.name }
     }
@@ -180,7 +186,7 @@ class BalanceProviderNotifier : Disposable {
         return try {
             OpenRouterSettingsService.getInstance()
                 .uiPreferencesManager.balanceProviderEnabled
-        } catch (e: IllegalStateException) {
+        } catch (_: IllegalStateException) {
             PluginLogger.Service.debug("Settings service unavailable, defaulting to enabled")
             true // Default to enabled if settings service is not available
         }
@@ -194,8 +200,9 @@ class BalanceProviderNotifier : Disposable {
     private fun getProviders(): List<BalanceProvider> {
         return try {
             EP_NAME.extensionList
-        } catch (e: IllegalStateException) {
-            PluginLogger.Service.debug("Cannot get extension list: ${e.message}")
+        } catch (_: IllegalStateException) {
+            // This is expected during plugin shutdown or when extension points are not available
+            PluginLogger.Service.debug("Cannot get extension list (expected during shutdown)")
             emptyList()
         }
     }
@@ -210,6 +217,7 @@ class BalanceProviderNotifier : Disposable {
      * @param methodName Name of the method (for logging)
      * @param block The code to execute
      */
+    @Suppress("TooGenericExceptionCaught") // Intentional: isolate provider exceptions
     private inline fun safeInvoke(
         provider: BalanceProvider,
         methodName: String,
@@ -217,7 +225,7 @@ class BalanceProviderNotifier : Disposable {
     ) {
         try {
             block()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             PluginLogger.Service.warn(
                 "BalanceProvider ${provider.javaClass.name}.$methodName() threw exception: ${e.message}",
                 e

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifier.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifier.kt
@@ -1,0 +1,231 @@
+package org.zhavoronkov.openrouter.services
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.extensions.ExtensionPointName
+import org.jetbrains.annotations.ApiStatus
+import org.zhavoronkov.openrouter.api.BalanceData
+import org.zhavoronkov.openrouter.api.BalanceProvider
+import org.zhavoronkov.openrouter.utils.PluginLogger
+
+/**
+ * Service responsible for notifying registered [BalanceProvider] implementations
+ * about balance updates, loading states, and errors.
+ *
+ * ## Security Features
+ * - **Configurable**: Users can disable balance sharing in Settings → Tools → OpenRouter
+ * - **Exception Isolation**: Exceptions from individual providers are caught and logged,
+ *   preventing one misbehaving provider from affecting others
+ * - **Immutable Data**: Only immutable [BalanceData] objects are shared with providers
+ *
+ * ## Usage
+ * This service is used internally by [OpenRouterStatsCache] to push balance updates
+ * to all registered extension point implementations.
+ *
+ * ```kotlin
+ * val notifier = BalanceProviderNotifier.getInstance()
+ * notifier.notifyBalanceUpdated(balanceData)
+ * ```
+ *
+ * @see BalanceProvider
+ * @see BalanceData
+ * @since 0.6.0
+ */
+@ApiStatus.Internal
+@Service(Service.Level.APP)
+class BalanceProviderNotifier : Disposable {
+
+    companion object {
+        /**
+         * Extension point name for balance providers.
+         * Fully qualified name: org.zhavoronkov.openrouter.balanceProvider
+         */
+        private val EP_NAME = ExtensionPointName.create<BalanceProvider>(
+            "org.zhavoronkov.openrouter.balanceProvider"
+        )
+
+        /**
+         * Gets the singleton instance of this service.
+         *
+         * @return The BalanceProviderNotifier instance
+         * @throws IllegalStateException if the application is not initialized
+         */
+        fun getInstance(): BalanceProviderNotifier {
+            return ApplicationManager.getApplication().getService(BalanceProviderNotifier::class.java)
+        }
+
+        /**
+         * Safely gets the instance, returning null if the application is not available.
+         * Useful for testing and shutdown scenarios.
+         *
+         * @return The BalanceProviderNotifier instance, or null if unavailable
+         */
+        fun getInstanceOrNull(): BalanceProviderNotifier? {
+            return try {
+                val app = ApplicationManager.getApplication() ?: return null
+                app.getService(BalanceProviderNotifier::class.java)
+            } catch (e: IllegalStateException) {
+                PluginLogger.Service.debug("BalanceProviderNotifier not available: ${e.message}")
+                null
+            }
+        }
+    }
+
+    /**
+     * Notifies all registered providers that balance data has been updated.
+     *
+     * This method:
+     * - Checks if the feature is enabled in settings
+     * - Iterates through all registered providers
+     * - Catches and logs exceptions from individual providers
+     *
+     * @param data The updated balance data to send to providers
+     */
+    fun notifyBalanceUpdated(data: BalanceData) {
+        if (!isEnabled()) {
+            PluginLogger.Service.debug("Balance provider notifications disabled, skipping update")
+            return
+        }
+
+        val providers = getProviders()
+        if (providers.isEmpty()) {
+            PluginLogger.Service.debug("No balance providers registered")
+            return
+        }
+
+        PluginLogger.Service.info("Notifying ${providers.size} balance provider(s) of update")
+
+        providers.forEach { provider ->
+            safeInvoke(provider, "onBalanceUpdated") {
+                provider.onBalanceUpdated(data)
+            }
+        }
+    }
+
+    /**
+     * Notifies all registered providers that balance loading has started.
+     */
+    fun notifyLoading() {
+        if (!isEnabled()) return
+
+        getProviders().forEach { provider ->
+            safeInvoke(provider, "onBalanceLoading") {
+                provider.onBalanceLoading()
+            }
+        }
+    }
+
+    /**
+     * Notifies all registered providers that balance loading has failed.
+     *
+     * @param error Human-readable error message
+     */
+    fun notifyError(error: String) {
+        if (!isEnabled()) return
+
+        val providers = getProviders()
+        if (providers.isEmpty()) return
+
+        PluginLogger.Service.debug("Notifying ${providers.size} balance provider(s) of error: $error")
+
+        providers.forEach { provider ->
+            safeInvoke(provider, "onBalanceError") {
+                provider.onBalanceError(error)
+            }
+        }
+    }
+
+    /**
+     * Checks if any balance providers are registered.
+     *
+     * @return true if at least one provider is registered
+     */
+    fun hasProviders(): Boolean {
+        return try {
+            EP_NAME.hasAnyExtensions()
+        } catch (e: IllegalStateException) {
+            PluginLogger.Service.debug("Cannot check for providers: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Gets the count of registered balance providers.
+     *
+     * @return Number of registered providers
+     */
+    fun getProviderCount(): Int {
+        return getProviders().size
+    }
+
+    /**
+     * Gets the list of registered provider class names (for debugging/logging).
+     *
+     * @return List of provider class names
+     */
+    fun getProviderNames(): List<String> {
+        return getProviders().map { it.javaClass.name }
+    }
+
+    /**
+     * Checks if balance provider notifications are enabled.
+     *
+     * The feature is controlled by the `balanceProviderEnabled` setting.
+     * Defaults to enabled if settings are unavailable.
+     *
+     * @return true if notifications should be sent to providers
+     */
+    private fun isEnabled(): Boolean {
+        return try {
+            OpenRouterSettingsService.getInstance()
+                .uiPreferencesManager.balanceProviderEnabled
+        } catch (e: IllegalStateException) {
+            PluginLogger.Service.debug("Settings service unavailable, defaulting to enabled")
+            true // Default to enabled if settings service is not available
+        }
+    }
+
+    /**
+     * Gets the list of registered providers.
+     *
+     * @return List of BalanceProvider instances, empty if unavailable
+     */
+    private fun getProviders(): List<BalanceProvider> {
+        return try {
+            EP_NAME.extensionList
+        } catch (e: IllegalStateException) {
+            PluginLogger.Service.debug("Cannot get extension list: ${e.message}")
+            emptyList()
+        }
+    }
+
+    /**
+     * Safely invokes a method on a provider, catching and logging any exceptions.
+     *
+     * This ensures that one misbehaving provider cannot prevent other providers
+     * from receiving notifications.
+     *
+     * @param provider The provider being invoked
+     * @param methodName Name of the method (for logging)
+     * @param block The code to execute
+     */
+    private inline fun safeInvoke(
+        provider: BalanceProvider,
+        methodName: String,
+        block: () -> Unit
+    ) {
+        try {
+            block()
+        } catch (e: Exception) {
+            PluginLogger.Service.warn(
+                "BalanceProvider ${provider.javaClass.name}.$methodName() threw exception: ${e.message}",
+                e
+            )
+        }
+    }
+
+    override fun dispose() {
+        PluginLogger.Service.info("BalanceProviderNotifier disposed")
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/OpenRouterStatsCache.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/OpenRouterStatsCache.kt
@@ -15,8 +15,8 @@ import org.zhavoronkov.openrouter.models.ApiKeysListResponse
 import org.zhavoronkov.openrouter.models.ApiResult
 import org.zhavoronkov.openrouter.models.CreditsData
 import org.zhavoronkov.openrouter.utils.PluginLogger
-import java.time.LocalDate
 import java.io.IOException
+import java.time.LocalDate
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -295,9 +295,10 @@ class OpenRouterStatsCache : Disposable {
         }
 
         // Also notify balance providers
+        @Suppress("TooGenericExceptionCaught") // Intentional: isolate provider failures
         try {
             BalanceProviderNotifier.getInstanceOrNull()?.notifyLoading()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             PluginLogger.Service.debug("Failed to notify balance providers of loading: ${e.message}")
         }
     }
@@ -322,6 +323,7 @@ class OpenRouterStatsCache : Disposable {
      * The push happens on a background thread to avoid blocking the UI,
      * and exceptions from individual providers are isolated.
      */
+    @Suppress("TooGenericExceptionCaught") // Intentional: isolate provider failures from main plugin
     private fun pushToBalanceProviders(credits: CreditsData, activity: List<ActivityData>?) {
         try {
             val notifier = BalanceProviderNotifier.getInstanceOrNull() ?: return
@@ -335,7 +337,7 @@ class OpenRouterStatsCache : Disposable {
             )
 
             notifier.notifyBalanceUpdated(balanceData)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             // Don't let balance provider failures affect the main plugin
             PluginLogger.Service.debug("Failed to notify balance providers: ${e.message}")
         }
@@ -367,9 +369,10 @@ class OpenRouterStatsCache : Disposable {
         }
 
         // Also notify balance providers
+        @Suppress("TooGenericExceptionCaught") // Intentional: isolate provider failures
         try {
             BalanceProviderNotifier.getInstanceOrNull()?.notifyError(message)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             PluginLogger.Service.debug("Failed to notify balance providers of error: ${e.message}")
         }
     }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/OpenRouterStatsCache.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/OpenRouterStatsCache.kt
@@ -8,12 +8,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import org.zhavoronkov.openrouter.api.BalanceData
 import org.zhavoronkov.openrouter.listeners.OpenRouterStatsListener
 import org.zhavoronkov.openrouter.models.ActivityData
 import org.zhavoronkov.openrouter.models.ApiKeysListResponse
 import org.zhavoronkov.openrouter.models.ApiResult
 import org.zhavoronkov.openrouter.models.CreditsData
 import org.zhavoronkov.openrouter.utils.PluginLogger
+import java.time.LocalDate
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -291,6 +293,13 @@ class OpenRouterStatsCache : Disposable {
                 .syncPublisher(OpenRouterStatsListener.TOPIC)
                 .onStatsLoading()
         }
+
+        // Also notify balance providers
+        try {
+            BalanceProviderNotifier.getInstanceOrNull()?.notifyLoading()
+        } catch (e: Exception) {
+            PluginLogger.Service.debug("Failed to notify balance providers of loading: ${e.message}")
+        }
     }
 
     private fun notifySuccess(credits: CreditsData, activity: List<ActivityData>?) {
@@ -299,6 +308,55 @@ class OpenRouterStatsCache : Disposable {
                 .syncPublisher(OpenRouterStatsListener.TOPIC)
                 .onStatsUpdated(credits, activity)
         }
+
+        // Push to extension point providers (balance sharing with other plugins)
+        pushToBalanceProviders(credits, activity)
+    }
+
+    /**
+     * Pushes balance data to registered BalanceProvider implementations.
+     *
+     * This allows other plugins (like TokenPulse) to receive real-time balance updates
+     * without needing direct access to OpenRouter's internal services.
+     *
+     * The push happens on a background thread to avoid blocking the UI,
+     * and exceptions from individual providers are isolated.
+     */
+    private fun pushToBalanceProviders(credits: CreditsData, activity: List<ActivityData>?) {
+        try {
+            val notifier = BalanceProviderNotifier.getInstanceOrNull() ?: return
+
+            val balanceData = BalanceData(
+                totalCredits = credits.totalCredits,
+                totalUsage = credits.totalUsage,
+                remainingCredits = credits.totalCredits - credits.totalUsage,
+                timestamp = System.currentTimeMillis(),
+                todayUsage = calculateTodayUsage(activity)
+            )
+
+            notifier.notifyBalanceUpdated(balanceData)
+        } catch (e: Exception) {
+            // Don't let balance provider failures affect the main plugin
+            PluginLogger.Service.debug("Failed to notify balance providers: ${e.message}")
+        }
+    }
+
+    /**
+     * Calculates today's usage from activity data.
+     *
+     * @param activity The activity data list, may be null
+     * @return Today's usage in USD, or null if not available
+     */
+    private fun calculateTodayUsage(activity: List<ActivityData>?): Double? {
+        if (activity.isNullOrEmpty()) return null
+
+        val today = LocalDate.now().toString() // Format: YYYY-MM-DD
+
+        val todayUsage = activity
+            .filter { it.date == today }
+            .sumOf { it.usage ?: 0.0 }
+
+        return if (todayUsage > 0) todayUsage else null
     }
 
     private fun notifyError(message: String) {
@@ -306,6 +364,13 @@ class OpenRouterStatsCache : Disposable {
             ApplicationManager.getApplication().messageBus
                 .syncPublisher(OpenRouterStatsListener.TOPIC)
                 .onStatsError(message)
+        }
+
+        // Also notify balance providers
+        try {
+            BalanceProviderNotifier.getInstanceOrNull()?.notifyError(message)
+        } catch (e: Exception) {
+            PluginLogger.Service.debug("Failed to notify balance providers of error: ${e.message}")
         }
     }
 

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/settings/UIPreferencesManager.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/settings/UIPreferencesManager.kt
@@ -51,4 +51,19 @@ class UIPreferencesManager(
             settings.defaultMaxTokens = value
             onStateChanged()
         }
+
+    /**
+     * Controls whether balance data is shared with other plugins via the extension point.
+     *
+     * When enabled (default), plugins that implement the BalanceProvider interface
+     * will receive real-time balance updates. Users can disable this for privacy.
+     *
+     * @see org.zhavoronkov.openrouter.api.BalanceProvider
+     */
+    var balanceProviderEnabled: Boolean
+        get() = settings.balanceProviderEnabled
+        set(value) {
+            settings.balanceProviderEnabled = value
+            onStateChanged()
+        }
 }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/settings/OpenRouterConfigurable.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/settings/OpenRouterConfigurable.kt
@@ -27,10 +27,12 @@ class OpenRouterConfigurable : Configurable {
             settingsService.uiPreferencesManager.autoRefresh = panel.isAutoRefreshEnabled()
             settingsService.uiPreferencesManager.refreshInterval = panel.getRefreshInterval()
             settingsService.uiPreferencesManager.showCosts = panel.shouldShowCosts()
+            settingsService.uiPreferencesManager.balanceProviderEnabled = panel.isBalanceProviderEnabled()
         } else {
             panel.setAutoRefresh(settingsService.uiPreferencesManager.autoRefresh)
             panel.setRefreshInterval(settingsService.uiPreferencesManager.refreshInterval)
             panel.setShowCosts(settingsService.uiPreferencesManager.showCosts)
+            panel.setBalanceProviderEnabled(settingsService.uiPreferencesManager.balanceProviderEnabled)
         }
         syncDefaultMaxTokens(panel, toService)
         syncProxySettings(panel, toService)
@@ -125,6 +127,7 @@ class OpenRouterConfigurable : Configurable {
         return panel.isAutoRefreshEnabled() != settingsService.uiPreferencesManager.autoRefresh ||
             panel.getRefreshInterval() != settingsService.uiPreferencesManager.refreshInterval ||
             panel.shouldShowCosts() != settingsService.uiPreferencesManager.showCosts ||
+            panel.isBalanceProviderEnabled() != settingsService.uiPreferencesManager.balanceProviderEnabled ||
             isSettingModified(panel, SettingType.DEFAULT_MAX_TOKENS) ||
             isSettingModified(panel, SettingType.PROXY_SETTINGS)
     }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/settings/OpenRouterSettingsPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/settings/OpenRouterSettingsPanel.kt
@@ -144,6 +144,9 @@ class OpenRouterSettingsPanel {
     private var proxyPortRangeStartSpinner: JSpinner
     private var proxyPortRangeEndSpinner: JSpinner
 
+    // Balance Provider setting
+    private var balanceProviderCheckBox: JBCheckBox
+
     // UI state tracking
     private var currentUiAuthScope: AuthScope = AuthScope.EXTENDED
     private lateinit var regularRadioButton: javax.swing.JRadioButton
@@ -270,6 +273,9 @@ class OpenRouterSettingsPanel {
             )
         )
 
+        // Initialize Balance Provider checkbox
+        balanceProviderCheckBox = JBCheckBox("Share balance data with other plugins")
+
         // Configure API key table
         apiKeyTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
         apiKeyTable.autoResizeMode = JTable.AUTO_RESIZE_ALL_COLUMNS
@@ -393,6 +399,23 @@ class OpenRouterSettingsPanel {
                         stopServerButton = button("Stop Server") { stopProxyServer() }.component
                         copyUrlButton = button("Copy Proxy URL") { copyProxyUrlToClipboard() }.component
                     }.layout(RowLayout.PARENT_GRID)
+                }
+
+                // Plugin Integration group
+                group("Plugin Integration") {
+                    row {
+                        cell(balanceProviderCheckBox)
+                    }
+                    row {
+                        comment(
+                            """
+                            When enabled, other installed plugins (like TokenPulse) can receive your 
+                            OpenRouter balance information (credits and usage) in real-time. This allows 
+                            third-party plugins to display your balance without needing separate API access.
+                            Disable this if you prefer not to share balance data with other plugins.
+                            """.trimIndent().replace("\n", " ")
+                        )
+                    }
                 }
 
                 // API Keys group (at the end, only visible with Extended scope)
@@ -795,6 +818,20 @@ class OpenRouterSettingsPanel {
         validatePortRange()
     }
 
+    // Balance Provider configuration methods
+
+    /**
+     * Returns whether balance data sharing with other plugins is enabled.
+     */
+    fun isBalanceProviderEnabled(): Boolean = balanceProviderCheckBox.isSelected
+
+    /**
+     * Sets whether balance data sharing with other plugins is enabled.
+     */
+    fun setBalanceProviderEnabled(enabled: Boolean) {
+        balanceProviderCheckBox.isSelected = enabled
+    }
+
     /**
      * Applies current proxy settings from UI to settings service.
      * This ensures immediate proxy server startup uses current UI values
@@ -891,6 +928,9 @@ class OpenRouterSettingsPanel {
 
             // Refresh Proxy Status
             updateProxyStatus()
+
+            // Refresh Balance Provider setting
+            setBalanceProviderEnabled(settingsService.uiPreferencesManager.balanceProviderEnabled)
 
             PluginLogger.Settings.info("Settings panel UI refreshed from service state")
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -178,6 +178,18 @@
 
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
+    <extensionPoints>
+        <!-- Balance Provider Extension Point
+             Allows other plugins to receive OpenRouter balance data updates.
+             Consumers implement BalanceProvider interface and register their implementation.
+             See: org.zhavoronkov.openrouter.api.BalanceProvider for documentation.
+        -->
+        <extensionPoint
+            name="balanceProvider"
+            interface="org.zhavoronkov.openrouter.api.BalanceProvider"
+            dynamic="true"/>
+    </extensionPoints>
+
     <extensions defaultExtensionNs="com.intellij">
         <!-- Notification group for plugin updates and announcements -->
         <notificationGroup id="OpenRouter Updates"
@@ -198,6 +210,7 @@
         <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.OpenRouterService"/>
         <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.OpenRouterSettingsService"/>
         <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.OpenRouterGenerationTrackingService"/>
+        <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.BalanceProviderNotifier"/>
         <!-- OpenRouterProxyService, OpenRouterStatsCache, CreditUsageHistoryService use @Service annotation -->
         
         <!-- Settings -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -210,8 +210,7 @@
         <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.OpenRouterService"/>
         <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.OpenRouterSettingsService"/>
         <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.OpenRouterGenerationTrackingService"/>
-        <applicationService serviceImplementation="org.zhavoronkov.openrouter.services.BalanceProviderNotifier"/>
-        <!-- OpenRouterProxyService, OpenRouterStatsCache, CreditUsageHistoryService use @Service annotation -->
+        <!-- BalanceProviderNotifier, OpenRouterProxyService, OpenRouterStatsCache, CreditUsageHistoryService use @Service annotation -->
         
         <!-- Settings -->
         <applicationConfigurable

--- a/src/test/kotlin/org/zhavoronkov/openrouter/aiassistant/ResponseJsonParserTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/aiassistant/ResponseJsonParserTest.kt
@@ -19,13 +19,16 @@ class ResponseJsonParserTest {
         @Test
         fun `returns JsonObject when member exists and is object`() {
             val json = JsonObject().apply {
-                add("nested", JsonObject().apply {
-                    addProperty("key", "value")
-                })
+                add(
+                    "nested",
+                    JsonObject().apply {
+                        addProperty("key", "value")
+                    }
+                )
             }
-            
+
             val result = ResponseJsonParser.getAsJsonObjectOrNull(json, "nested")
-            
+
             assertNotNull(result)
             assertEquals("value", result?.get("key")?.asString)
         }
@@ -33,9 +36,9 @@ class ResponseJsonParserTest {
         @Test
         fun `returns null when member does not exist`() {
             val json = JsonObject()
-            
+
             val result = ResponseJsonParser.getAsJsonObjectOrNull(json, "missing")
-            
+
             assertNull(result)
         }
 
@@ -44,9 +47,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 addProperty("notObject", "string value")
             }
-            
+
             val result = ResponseJsonParser.getAsJsonObjectOrNull(json, "notObject")
-            
+
             assertNull(result)
         }
 
@@ -55,9 +58,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 add("array", JsonArray())
             }
-            
+
             val result = ResponseJsonParser.getAsJsonObjectOrNull(json, "array")
-            
+
             assertNull(result)
         }
 
@@ -66,9 +69,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 add("nullValue", null)
             }
-            
+
             val result = ResponseJsonParser.getAsJsonObjectOrNull(json, "nullValue")
-            
+
             assertNull(result)
         }
     }
@@ -80,14 +83,17 @@ class ResponseJsonParserTest {
         @Test
         fun `returns JsonArray when member exists and is array`() {
             val json = JsonObject().apply {
-                add("items", JsonArray().apply {
-                    add("item1")
-                    add("item2")
-                })
+                add(
+                    "items",
+                    JsonArray().apply {
+                        add("item1")
+                        add("item2")
+                    }
+                )
             }
-            
+
             val result = ResponseJsonParser.getAsJsonArrayOrNull(json, "items")
-            
+
             assertNotNull(result)
             assertEquals(2, result?.size())
         }
@@ -95,9 +101,9 @@ class ResponseJsonParserTest {
         @Test
         fun `returns null when member does not exist`() {
             val json = JsonObject()
-            
+
             val result = ResponseJsonParser.getAsJsonArrayOrNull(json, "missing")
-            
+
             assertNull(result)
         }
 
@@ -106,9 +112,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 addProperty("notArray", "string value")
             }
-            
+
             val result = ResponseJsonParser.getAsJsonArrayOrNull(json, "notArray")
-            
+
             assertNull(result)
         }
 
@@ -117,9 +123,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 add("object", JsonObject())
             }
-            
+
             val result = ResponseJsonParser.getAsJsonArrayOrNull(json, "object")
-            
+
             assertNull(result)
         }
 
@@ -128,9 +134,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 add("emptyArray", JsonArray())
             }
-            
+
             val result = ResponseJsonParser.getAsJsonArrayOrNull(json, "emptyArray")
-            
+
             assertNotNull(result)
             assertEquals(0, result?.size())
         }
@@ -145,18 +151,18 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 addProperty("name", "test value")
             }
-            
+
             val result = ResponseJsonParser.getAsStringOrNull(json, "name")
-            
+
             assertEquals("test value", result)
         }
 
         @Test
         fun `returns null when member does not exist`() {
             val json = JsonObject()
-            
+
             val result = ResponseJsonParser.getAsStringOrNull(json, "missing")
-            
+
             assertNull(result)
         }
 
@@ -165,9 +171,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 add("object", JsonObject())
             }
-            
+
             val result = ResponseJsonParser.getAsStringOrNull(json, "object")
-            
+
             assertNull(result)
         }
 
@@ -176,9 +182,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 add("array", JsonArray())
             }
-            
+
             val result = ResponseJsonParser.getAsStringOrNull(json, "array")
-            
+
             assertNull(result)
         }
 
@@ -187,9 +193,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 addProperty("number", 42)
             }
-            
+
             val result = ResponseJsonParser.getAsStringOrNull(json, "number")
-            
+
             assertEquals("42", result)
         }
 
@@ -198,9 +204,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 addProperty("flag", true)
             }
-            
+
             val result = ResponseJsonParser.getAsStringOrNull(json, "flag")
-            
+
             assertEquals("true", result)
         }
 
@@ -209,9 +215,9 @@ class ResponseJsonParserTest {
             val json = JsonObject().apply {
                 addProperty("empty", "")
             }
-            
+
             val result = ResponseJsonParser.getAsStringOrNull(json, "empty")
-            
+
             assertEquals("", result)
         }
     }
@@ -223,19 +229,25 @@ class ResponseJsonParserTest {
         @Test
         fun `handles deeply nested structures`() {
             val json = JsonObject().apply {
-                add("level1", JsonObject().apply {
-                    add("level2", JsonObject().apply {
-                        addProperty("value", "deep")
-                    })
-                })
+                add(
+                    "level1",
+                    JsonObject().apply {
+                        add(
+                            "level2",
+                            JsonObject().apply {
+                                addProperty("value", "deep")
+                            }
+                        )
+                    }
+                )
             }
-            
+
             val level1 = ResponseJsonParser.getAsJsonObjectOrNull(json, "level1")
             assertNotNull(level1)
-            
+
             val level2 = ResponseJsonParser.getAsJsonObjectOrNull(level1!!, "level2")
             assertNotNull(level2)
-            
+
             val value = ResponseJsonParser.getAsStringOrNull(level2!!, "value")
             assertEquals("deep", value)
         }
@@ -248,7 +260,7 @@ class ResponseJsonParserTest {
                 add("object", JsonObject())
                 add("array", JsonArray())
             }
-            
+
             assertEquals("text", ResponseJsonParser.getAsStringOrNull(json, "string"))
             assertEquals("123", ResponseJsonParser.getAsStringOrNull(json, "number"))
             assertNotNull(ResponseJsonParser.getAsJsonObjectOrNull(json, "object"))

--- a/src/test/kotlin/org/zhavoronkov/openrouter/api/BalanceDataTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/api/BalanceDataTest.kt
@@ -1,0 +1,418 @@
+package org.zhavoronkov.openrouter.api
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [BalanceData] data class.
+ *
+ * Tests cover:
+ * - Validation (negative values, zero timestamp)
+ * - Percentage calculations
+ * - Formatting methods
+ * - Low balance detection
+ * - Edge cases
+ */
+@DisplayName("BalanceData Tests")
+class BalanceDataTest {
+
+    companion object {
+        private const val DEFAULT_TIMESTAMP = 1711526400000L // March 27, 2024
+    }
+
+    @Nested
+    @DisplayName("Validation Tests")
+    inner class ValidationTests {
+
+        @Test
+        @DisplayName("should reject negative totalCredits")
+        fun rejectsNegativeTotalCredits() {
+            val exception = assertThrows(IllegalArgumentException::class.java) {
+                BalanceData(
+                    totalCredits = -1.0,
+                    totalUsage = 0.0,
+                    remainingCredits = 0.0,
+                    timestamp = DEFAULT_TIMESTAMP
+                )
+            }
+            assertTrue(exception.message?.contains("totalCredits") == true)
+        }
+
+        @Test
+        @DisplayName("should reject negative totalUsage")
+        fun rejectsNegativeTotalUsage() {
+            val exception = assertThrows(IllegalArgumentException::class.java) {
+                BalanceData(
+                    totalCredits = 100.0,
+                    totalUsage = -1.0,
+                    remainingCredits = 100.0,
+                    timestamp = DEFAULT_TIMESTAMP
+                )
+            }
+            assertTrue(exception.message?.contains("totalUsage") == true)
+        }
+
+        @Test
+        @DisplayName("should reject zero timestamp")
+        fun rejectsZeroTimestamp() {
+            val exception = assertThrows(IllegalArgumentException::class.java) {
+                BalanceData(
+                    totalCredits = 100.0,
+                    totalUsage = 0.0,
+                    remainingCredits = 100.0,
+                    timestamp = 0
+                )
+            }
+            assertTrue(exception.message?.contains("timestamp") == true)
+        }
+
+        @Test
+        @DisplayName("should reject negative timestamp")
+        fun rejectsNegativeTimestamp() {
+            val exception = assertThrows(IllegalArgumentException::class.java) {
+                BalanceData(
+                    totalCredits = 100.0,
+                    totalUsage = 0.0,
+                    remainingCredits = 100.0,
+                    timestamp = -1
+                )
+            }
+            assertTrue(exception.message?.contains("timestamp") == true)
+        }
+
+        @Test
+        @DisplayName("should reject negative todayUsage when provided")
+        fun rejectsNegativeTodayUsage() {
+            val exception = assertThrows(IllegalArgumentException::class.java) {
+                BalanceData(
+                    totalCredits = 100.0,
+                    totalUsage = 50.0,
+                    remainingCredits = 50.0,
+                    timestamp = DEFAULT_TIMESTAMP,
+                    todayUsage = -5.0
+                )
+            }
+            assertTrue(exception.message?.contains("todayUsage") == true)
+        }
+
+        @Test
+        @DisplayName("should allow zero values for credits and usage")
+        fun allowsZeroValues() {
+            val data = BalanceData(
+                totalCredits = 0.0,
+                totalUsage = 0.0,
+                remainingCredits = 0.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(0.0, data.totalCredits)
+            assertEquals(0.0, data.totalUsage)
+        }
+
+        @Test
+        @DisplayName("should allow null todayUsage")
+        fun allowsNullTodayUsage() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 50.0,
+                remainingCredits = 50.0,
+                timestamp = DEFAULT_TIMESTAMP,
+                todayUsage = null
+            )
+            assertNull(data.todayUsage)
+        }
+
+        @Test
+        @DisplayName("should allow zero todayUsage")
+        fun allowsZeroTodayUsage() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 50.0,
+                remainingCredits = 50.0,
+                timestamp = DEFAULT_TIMESTAMP,
+                todayUsage = 0.0
+            )
+            assertEquals(0.0, data.todayUsage)
+        }
+    }
+
+    @Nested
+    @DisplayName("Percentage Calculation Tests")
+    inner class PercentageTests {
+
+        @Test
+        @DisplayName("remainingPercentage should calculate correctly")
+        fun remainingPercentageCalculation() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(75.0, data.remainingPercentage(), 0.001)
+        }
+
+        @Test
+        @DisplayName("remainingPercentage should return 100 when totalCredits is zero")
+        fun remainingPercentageWithZeroCredits() {
+            val data = BalanceData(
+                totalCredits = 0.0,
+                totalUsage = 0.0,
+                remainingCredits = 0.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(100.0, data.remainingPercentage(), 0.001)
+        }
+
+        @Test
+        @DisplayName("usagePercentage should calculate correctly")
+        fun usagePercentageCalculation() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(25.0, data.usagePercentage(), 0.001)
+        }
+
+        @Test
+        @DisplayName("usagePercentage should return 0 when totalCredits is zero")
+        fun usagePercentageWithZeroCredits() {
+            val data = BalanceData(
+                totalCredits = 0.0,
+                totalUsage = 0.0,
+                remainingCredits = 0.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(0.0, data.usagePercentage(), 0.001)
+        }
+    }
+
+    @Nested
+    @DisplayName("Low Balance Detection Tests")
+    inner class LowBalanceTests {
+
+        @Test
+        @DisplayName("isLowBalance should return true when remaining is less than 10%")
+        fun lowBalanceDetection() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 92.0,
+                remainingCredits = 8.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertTrue(data.isLowBalance())
+        }
+
+        @Test
+        @DisplayName("isLowBalance should return false when remaining is 10% or more")
+        fun notLowBalance() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 90.0,
+                remainingCredits = 10.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertFalse(data.isLowBalance())
+        }
+
+        @Test
+        @DisplayName("isLowBalance should return false when totalCredits is zero")
+        fun lowBalanceWithZeroCredits() {
+            val data = BalanceData(
+                totalCredits = 0.0,
+                totalUsage = 0.0,
+                remainingCredits = 0.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            // When totalCredits is 0, remainingPercentage returns 100, so not low balance
+            assertFalse(data.isLowBalance())
+        }
+    }
+
+    @Nested
+    @DisplayName("Formatting Tests")
+    inner class FormattingTests {
+
+        @Test
+        @DisplayName("formattedRemaining should format with dollar sign and two decimals")
+        fun formattedRemaining() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.50,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals("\$75.50", data.formattedRemaining())
+        }
+
+        @Test
+        @DisplayName("formattedRemaining should handle small values")
+        fun formattedRemainingSmallValues() {
+            val data = BalanceData(
+                totalCredits = 1.0,
+                totalUsage = 0.99,
+                remainingCredits = 0.01,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals("\$0.01", data.formattedRemaining())
+        }
+
+        @Test
+        @DisplayName("formattedTodayUsage should format when value is present")
+        fun formattedTodayUsagePresent() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP,
+                todayUsage = 5.25
+            )
+            assertEquals("\$5.25", data.formattedTodayUsage())
+        }
+
+        @Test
+        @DisplayName("formattedTodayUsage should return N/A when null")
+        fun formattedTodayUsageNull() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP,
+                todayUsage = null
+            )
+            assertEquals("N/A", data.formattedTodayUsage())
+        }
+
+        @Test
+        @DisplayName("toString should include all key values")
+        fun toStringFormat() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP,
+                todayUsage = 5.0
+            )
+            val str = data.toString()
+            assertTrue(str.contains("75.00"))
+            assertTrue(str.contains("25.00"))
+            assertTrue(str.contains("100.00"))
+            assertTrue(str.contains("5.00"))
+        }
+    }
+
+    @Nested
+    @DisplayName("Data Class Tests")
+    inner class DataClassTests {
+
+        @Test
+        @DisplayName("should support copy with modified values")
+        fun copySupport() {
+            val original = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            val copied = original.copy(totalUsage = 50.0)
+
+            assertEquals(100.0, copied.totalCredits)
+            assertEquals(50.0, copied.totalUsage)
+            assertEquals(75.0, copied.remainingCredits) // Not automatically recalculated
+        }
+
+        @Test
+        @DisplayName("should have correct equality")
+        fun equalityCheck() {
+            val data1 = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            val data2 = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(data1, data2)
+            assertEquals(data1.hashCode(), data2.hashCode())
+        }
+
+        @Test
+        @DisplayName("should use default source value")
+        fun defaultSourceValue() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(BalanceData.SOURCE_OPENROUTER, data.source)
+        }
+
+        @Test
+        @DisplayName("should allow custom source value")
+        fun customSourceValue() {
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP,
+                source = "custom-source"
+            )
+            assertEquals("custom-source", data.source)
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    inner class EdgeCases {
+
+        @Test
+        @DisplayName("should handle very large values")
+        fun largeValues() {
+            val data = BalanceData(
+                totalCredits = 1_000_000.0,
+                totalUsage = 500_000.0,
+                remainingCredits = 500_000.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(50.0, data.remainingPercentage(), 0.001)
+            assertFalse(data.isLowBalance())
+        }
+
+        @Test
+        @DisplayName("should handle very small decimal values")
+        fun smallDecimalValues() {
+            val data = BalanceData(
+                totalCredits = 0.001,
+                totalUsage = 0.0001,
+                remainingCredits = 0.0009,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(90.0, data.remainingPercentage(), 0.1)
+        }
+
+        @Test
+        @DisplayName("should handle remaining greater than total (edge case)")
+        fun remainingGreaterThanTotal() {
+            // This is technically invalid but we don't validate the relationship
+            val data = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 0.0,
+                remainingCredits = 150.0, // Invalid but allowed
+                timestamp = DEFAULT_TIMESTAMP
+            )
+            assertEquals(150.0, data.remainingPercentage(), 0.001)
+        }
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/openrouter/listeners/OpenRouterSettingsListenerTopicTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/listeners/OpenRouterSettingsListenerTopicTest.kt
@@ -21,15 +21,15 @@ class OpenRouterSettingsListenerTopicTest {
     @Test
     fun `listener interface can be implemented`() {
         var settingsChangedCalled = false
-        
+
         val listener = object : OpenRouterSettingsListener {
             override fun onSettingsChanged() {
                 settingsChangedCalled = true
             }
         }
-        
+
         listener.onSettingsChanged()
-        
+
         assertEquals(true, settingsChangedCalled)
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderIntegrationTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderIntegrationTest.kt
@@ -1,0 +1,390 @@
+package org.zhavoronkov.openrouter.services
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.zhavoronkov.openrouter.api.BalanceData
+import org.zhavoronkov.openrouter.models.ActivityData
+import org.zhavoronkov.openrouter.models.CreditsData
+import java.time.LocalDate
+
+/**
+ * Integration tests for the BalanceProvider extension point feature.
+ *
+ * Tests cover:
+ * - OpenRouterStatsCache integration
+ * - BalanceData creation from CreditsData
+ * - Today's usage calculation from ActivityData
+ * - Settings integration (balanceProviderEnabled)
+ *
+ * Note: These tests verify the integration logic without requiring IntelliJ platform initialization.
+ * Full end-to-end tests with extension point registration require IDE environment.
+ */
+@DisplayName("Balance Provider Integration Tests")
+class BalanceProviderIntegrationTest {
+
+    companion object {
+        private const val DEFAULT_TIMESTAMP = 1711526400000L
+    }
+
+    @Nested
+    @DisplayName("BalanceData Creation Tests")
+    inner class BalanceDataCreationTests {
+
+        @Test
+        @DisplayName("should create BalanceData from CreditsData")
+        fun createBalanceDataFromCreditsData() {
+            val creditsData = CreditsData(
+                totalCredits = 100.0,
+                totalUsage = 25.0
+            )
+
+            val balanceData = BalanceData(
+                totalCredits = creditsData.totalCredits,
+                totalUsage = creditsData.totalUsage,
+                remainingCredits = creditsData.totalCredits - creditsData.totalUsage,
+                timestamp = System.currentTimeMillis()
+            )
+
+            assertEquals(100.0, balanceData.totalCredits)
+            assertEquals(25.0, balanceData.totalUsage)
+            assertEquals(75.0, balanceData.remainingCredits)
+            assertTrue(balanceData.timestamp > 0)
+        }
+
+        @Test
+        @DisplayName("should calculate remaining credits correctly")
+        fun calculateRemainingCredits() {
+            val creditsData = CreditsData(
+                totalCredits = 50.0,
+                totalUsage = 30.0
+            )
+
+            val remaining = creditsData.totalCredits - creditsData.totalUsage
+
+            assertEquals(20.0, remaining)
+        }
+
+        @Test
+        @DisplayName("should handle zero credits")
+        fun handleZeroCredits() {
+            val creditsData = CreditsData(
+                totalCredits = 0.0,
+                totalUsage = 0.0
+            )
+
+            val balanceData = BalanceData(
+                totalCredits = creditsData.totalCredits,
+                totalUsage = creditsData.totalUsage,
+                remainingCredits = creditsData.totalCredits - creditsData.totalUsage,
+                timestamp = System.currentTimeMillis()
+            )
+
+            assertEquals(0.0, balanceData.totalCredits)
+            assertEquals(0.0, balanceData.totalUsage)
+            assertEquals(0.0, balanceData.remainingCredits)
+        }
+    }
+
+    @Nested
+    @DisplayName("Today Usage Calculation Tests")
+    inner class TodayUsageCalculationTests {
+
+        @Test
+        @DisplayName("should calculate today's usage from activity data")
+        fun calculateTodayUsage() {
+            val today = LocalDate.now().toString()
+            val yesterday = LocalDate.now().minusDays(1).toString()
+
+            val activityData = listOf(
+                createActivityData(today, 5.0),
+                createActivityData(today, 3.0),
+                createActivityData(yesterday, 10.0) // Should not be included
+            )
+
+            val todayUsage = activityData
+                .filter { it.date == today }
+                .sumOf { it.usage ?: 0.0 }
+
+            assertEquals(8.0, todayUsage)
+        }
+
+        @Test
+        @DisplayName("should return zero for no today's activity")
+        fun noTodayActivity() {
+            val yesterday = LocalDate.now().minusDays(1).toString()
+
+            val activityData = listOf(
+                createActivityData(yesterday, 5.0),
+                createActivityData(yesterday, 3.0)
+            )
+
+            val today = LocalDate.now().toString()
+            val todayUsage = activityData
+                .filter { it.date == today }
+                .sumOf { it.usage ?: 0.0 }
+
+            assertEquals(0.0, todayUsage)
+        }
+
+        @Test
+        @DisplayName("should handle null usage values")
+        fun handleNullUsageValues() {
+            val today = LocalDate.now().toString()
+
+            val activityData = listOf(
+                createActivityData(today, 5.0),
+                createActivityDataWithNullUsage(today),
+                createActivityData(today, 3.0)
+            )
+
+            val todayUsage = activityData
+                .filter { it.date == today }
+                .sumOf { it.usage ?: 0.0 }
+
+            assertEquals(8.0, todayUsage)
+        }
+
+        @Test
+        @DisplayName("should handle empty activity list")
+        fun handleEmptyActivityList() {
+            val activityData = emptyList<ActivityData>()
+            val today = LocalDate.now().toString()
+
+            val todayUsage = activityData
+                .filter { it.date == today }
+                .sumOf { it.usage ?: 0.0 }
+
+            assertEquals(0.0, todayUsage)
+        }
+
+        @Test
+        @DisplayName("should handle null date in activity")
+        fun handleNullDateInActivity() {
+            val today = LocalDate.now().toString()
+
+            val activityData = listOf(
+                createActivityData(today, 5.0),
+                createActivityDataWithNullDate(3.0), // Null date should be filtered out
+                createActivityData(today, 2.0)
+            )
+
+            val todayUsage = activityData
+                .filter { it.date == today }
+                .sumOf { it.usage ?: 0.0 }
+
+            assertEquals(7.0, todayUsage)
+        }
+
+        private fun createActivityData(date: String, usage: Double): ActivityData {
+            return ActivityData(
+                date = date,
+                model = "test-model",
+                modelPermaslug = "test-model",
+                endpointId = "ep-1",
+                providerName = "openai",
+                usage = usage,
+                byokUsageInference = null,
+                requests = 1,
+                promptTokens = 100,
+                completionTokens = 50,
+                reasoningTokens = null
+            )
+        }
+
+        private fun createActivityDataWithNullUsage(date: String): ActivityData {
+            return ActivityData(
+                date = date,
+                model = "test-model",
+                modelPermaslug = "test-model",
+                endpointId = "ep-1",
+                providerName = "openai",
+                usage = null, // Null usage
+                byokUsageInference = null,
+                requests = 1,
+                promptTokens = 100,
+                completionTokens = 50,
+                reasoningTokens = null
+            )
+        }
+
+        private fun createActivityDataWithNullDate(usage: Double): ActivityData {
+            return ActivityData(
+                date = null, // Null date
+                model = "test-model",
+                modelPermaslug = "test-model",
+                endpointId = "ep-1",
+                providerName = "openai",
+                usage = usage,
+                byokUsageInference = null,
+                requests = 1,
+                promptTokens = 100,
+                completionTokens = 50,
+                reasoningTokens = null
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("BalanceData with Today Usage Tests")
+    inner class BalanceDataWithTodayUsageTests {
+
+        @Test
+        @DisplayName("should create BalanceData with today's usage")
+        fun createBalanceDataWithTodayUsage() {
+            val creditsData = CreditsData(
+                totalCredits = 100.0,
+                totalUsage = 25.0
+            )
+
+            val todayUsage = 5.0
+
+            val balanceData = BalanceData(
+                totalCredits = creditsData.totalCredits,
+                totalUsage = creditsData.totalUsage,
+                remainingCredits = creditsData.totalCredits - creditsData.totalUsage,
+                timestamp = System.currentTimeMillis(),
+                todayUsage = todayUsage
+            )
+
+            assertEquals(100.0, balanceData.totalCredits)
+            assertEquals(25.0, balanceData.totalUsage)
+            assertEquals(75.0, balanceData.remainingCredits)
+            assertEquals(5.0, balanceData.todayUsage)
+        }
+
+        @Test
+        @DisplayName("should handle null today's usage")
+        fun handleNullTodayUsage() {
+            val creditsData = CreditsData(
+                totalCredits = 100.0,
+                totalUsage = 25.0
+            )
+
+            val balanceData = BalanceData(
+                totalCredits = creditsData.totalCredits,
+                totalUsage = creditsData.totalUsage,
+                remainingCredits = creditsData.totalCredits - creditsData.totalUsage,
+                timestamp = System.currentTimeMillis(),
+                todayUsage = null
+            )
+
+            assertNull(balanceData.todayUsage)
+            assertEquals("N/A", balanceData.formattedTodayUsage())
+        }
+    }
+
+    @Nested
+    @DisplayName("Settings Integration Tests")
+    inner class SettingsIntegrationTests {
+
+        @Test
+        @DisplayName("OpenRouterSettings should have balanceProviderEnabled field")
+        fun settingsHasBalanceProviderEnabledField() {
+            val settingsClass = org.zhavoronkov.openrouter.models.OpenRouterSettings::class.java
+
+            // Check if the field exists
+            val field = settingsClass.getDeclaredField("balanceProviderEnabled")
+            assertNotNull(field, "OpenRouterSettings should have balanceProviderEnabled field")
+            assertEquals(Boolean::class.javaPrimitiveType, field.type)
+        }
+
+        @Test
+        @DisplayName("balanceProviderEnabled should default to true")
+        fun balanceProviderEnabledDefaultsToTrue() {
+            val settings = org.zhavoronkov.openrouter.models.OpenRouterSettings()
+            assertTrue(settings.balanceProviderEnabled, "balanceProviderEnabled should default to true")
+        }
+
+        @Test
+        @DisplayName("balanceProviderEnabled should be modifiable")
+        fun balanceProviderEnabledIsModifiable() {
+            val settings = org.zhavoronkov.openrouter.models.OpenRouterSettings()
+
+            settings.balanceProviderEnabled = false
+            assertEquals(false, settings.balanceProviderEnabled)
+
+            settings.balanceProviderEnabled = true
+            assertEquals(true, settings.balanceProviderEnabled)
+        }
+    }
+
+    @Nested
+    @DisplayName("OpenRouterStatsCache Structure Tests")
+    inner class StatsCacheStructureTests {
+
+        @Test
+        @DisplayName("OpenRouterStatsCache should have methods for balance provider integration")
+        fun statsCacheHasRequiredMethods() {
+            val cacheClass = OpenRouterStatsCache::class.java
+
+            // Verify public methods exist
+            assertNotNull(cacheClass.getDeclaredMethod("getCachedCredits"))
+            assertNotNull(cacheClass.getDeclaredMethod("getCachedActivity"))
+            assertNotNull(cacheClass.getDeclaredMethod("refresh"))
+        }
+
+        @Test
+        @DisplayName("OpenRouterStatsCache should import BalanceData")
+        fun statsCacheImportsBalanceData() {
+            // This test verifies that the import was added correctly
+            // by checking if BalanceData can be referenced in the context of StatsCache
+            val balanceData = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = System.currentTimeMillis()
+            )
+            assertNotNull(balanceData)
+        }
+    }
+
+    @Nested
+    @DisplayName("Extension Point Declaration Tests")
+    inner class ExtensionPointDeclarationTests {
+
+        @Test
+        @DisplayName("BalanceProvider interface should be in api package")
+        fun balanceProviderInApiPackage() {
+            val interfaceClass = org.zhavoronkov.openrouter.api.BalanceProvider::class.java
+            assertEquals("org.zhavoronkov.openrouter.api", interfaceClass.packageName)
+        }
+
+        @Test
+        @DisplayName("BalanceData class should be in api package")
+        fun balanceDataInApiPackage() {
+            val dataClass = BalanceData::class.java
+            assertEquals("org.zhavoronkov.openrouter.api", dataClass.packageName)
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should be in services package")
+        fun notifierInServicesPackage() {
+            val notifierClass = BalanceProviderNotifier::class.java
+            assertEquals("org.zhavoronkov.openrouter.services", notifierClass.packageName)
+        }
+    }
+
+    @Nested
+    @DisplayName("UIPreferencesManager Integration Tests")
+    inner class UIPreferencesManagerTests {
+
+        @Test
+        @DisplayName("UIPreferencesManager should have balanceProviderEnabled property")
+        fun uiPreferencesManagerHasBalanceProviderEnabled() {
+            val managerClass = org.zhavoronkov.openrouter.services.settings.UIPreferencesManager::class.java
+
+            // Check for getter
+            val getter = managerClass.getDeclaredMethod("getBalanceProviderEnabled")
+            assertNotNull(getter, "UIPreferencesManager should have getBalanceProviderEnabled method")
+
+            // Check for setter
+            val setter = managerClass.getDeclaredMethod("setBalanceProviderEnabled", Boolean::class.javaPrimitiveType)
+            assertNotNull(setter, "UIPreferencesManager should have setBalanceProviderEnabled method")
+        }
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderIntegrationTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderIntegrationTest.kt
@@ -27,10 +27,6 @@ import java.time.LocalDate
 @DisplayName("Balance Provider Integration Tests")
 class BalanceProviderIntegrationTest {
 
-    companion object {
-        private const val DEFAULT_TIMESTAMP = 1711526400000L
-    }
-
     @Nested
     @DisplayName("BalanceData Creation Tests")
     inner class BalanceDataCreationTests {
@@ -212,6 +208,7 @@ class BalanceProviderIntegrationTest {
             )
         }
 
+        @Suppress("SameParameterValue") // Test helper with fixed value for specific test case
         private fun createActivityDataWithNullDate(usage: Double): ActivityData {
             return ActivityData(
                 date = null, // Null date

--- a/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifierTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifierTest.kt
@@ -253,19 +253,24 @@ class BalanceProviderNotifierTest {
     }
 
     /**
+     * Custom exception for testing provider isolation.
+     */
+    private class ProviderTestException(message: String) : Exception(message)
+
+    /**
      * A provider that throws exceptions for testing isolation.
      */
     private class ThrowingProvider : BalanceProvider {
         override fun onBalanceUpdated(data: BalanceData) {
-            throw RuntimeException("Test exception from onBalanceUpdated")
+            throw ProviderTestException("Test exception from onBalanceUpdated")
         }
 
         override fun onBalanceLoading() {
-            throw RuntimeException("Test exception from onBalanceLoading")
+            throw ProviderTestException("Test exception from onBalanceLoading")
         }
 
         override fun onBalanceError(error: String) {
-            throw RuntimeException("Test exception from onBalanceError")
+            throw ProviderTestException("Test exception from onBalanceError")
         }
     }
 
@@ -274,10 +279,11 @@ class BalanceProviderNotifierTest {
     inner class ExceptionHandlingTests {
 
         @Test
-        @DisplayName("Throwing provider should not prevent interface implementation")
+        @DisplayName("Throwing provider should be assignable to BalanceProvider type")
         fun throwingProviderImplementsInterface() {
-            val provider = ThrowingProvider()
-            assertTrue(provider is BalanceProvider)
+            // Verify ThrowingProvider can be used as BalanceProvider
+            val provider: BalanceProvider = ThrowingProvider()
+            assertNotNull(provider, "ThrowingProvider should implement BalanceProvider")
         }
 
         @Test
@@ -294,11 +300,11 @@ class BalanceProviderNotifierTest {
             var exceptionThrown = false
             try {
                 provider.onBalanceUpdated(testData)
-            } catch (e: RuntimeException) {
+            } catch (e: ProviderTestException) {
                 exceptionThrown = true
                 assertTrue(e.message?.contains("Test exception") == true)
             }
-            assertTrue(exceptionThrown, "Expected RuntimeException to be thrown")
+            assertTrue(exceptionThrown, "Expected ProviderTestException to be thrown")
         }
     }
 

--- a/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifierTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/services/BalanceProviderNotifierTest.kt
@@ -1,0 +1,352 @@
+package org.zhavoronkov.openrouter.services
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.zhavoronkov.openrouter.api.BalanceData
+import org.zhavoronkov.openrouter.api.BalanceProvider
+
+/**
+ * Unit tests for [BalanceProviderNotifier] service.
+ *
+ * Tests cover:
+ * - Service structure and Disposable implementation
+ * - Method existence verification
+ * - BalanceProvider interface contract
+ *
+ * Note: These tests verify class structure without requiring IntelliJ platform initialization.
+ * Integration tests with actual extension point registration require IDE environment.
+ */
+@DisplayName("BalanceProviderNotifier Tests")
+class BalanceProviderNotifierTest {
+
+    companion object {
+        private const val DEFAULT_TIMESTAMP = 1711526400000L
+    }
+
+    @Nested
+    @DisplayName("Service Structure Tests")
+    inner class ServiceStructureTests {
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should implement Disposable")
+        fun implementsDisposable() {
+            assertTrue(
+                com.intellij.openapi.Disposable::class.java.isAssignableFrom(BalanceProviderNotifier::class.java),
+                "BalanceProviderNotifier must implement Disposable for dynamic plugin support"
+            )
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have getInstance method")
+        fun hasGetInstanceMethod() {
+            val method = BalanceProviderNotifier.Companion::class.java
+                .getDeclaredMethod("getInstance")
+            assertNotNull(method, "BalanceProviderNotifier should have getInstance() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have getInstanceOrNull method")
+        fun hasGetInstanceOrNullMethod() {
+            val method = BalanceProviderNotifier.Companion::class.java
+                .getDeclaredMethod("getInstanceOrNull")
+            assertNotNull(method, "BalanceProviderNotifier should have getInstanceOrNull() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have notifyBalanceUpdated method")
+        fun hasNotifyBalanceUpdatedMethod() {
+            val method = BalanceProviderNotifier::class.java
+                .getDeclaredMethod("notifyBalanceUpdated", BalanceData::class.java)
+            assertNotNull(method, "BalanceProviderNotifier should have notifyBalanceUpdated() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have notifyLoading method")
+        fun hasNotifyLoadingMethod() {
+            val method = BalanceProviderNotifier::class.java
+                .getDeclaredMethod("notifyLoading")
+            assertNotNull(method, "BalanceProviderNotifier should have notifyLoading() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have notifyError method")
+        fun hasNotifyErrorMethod() {
+            val method = BalanceProviderNotifier::class.java
+                .getDeclaredMethod("notifyError", String::class.java)
+            assertNotNull(method, "BalanceProviderNotifier should have notifyError() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have hasProviders method")
+        fun hasHasProvidersMethod() {
+            val method = BalanceProviderNotifier::class.java
+                .getDeclaredMethod("hasProviders")
+            assertNotNull(method, "BalanceProviderNotifier should have hasProviders() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have getProviderCount method")
+        fun hasGetProviderCountMethod() {
+            val method = BalanceProviderNotifier::class.java
+                .getDeclaredMethod("getProviderCount")
+            assertNotNull(method, "BalanceProviderNotifier should have getProviderCount() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have getProviderNames method")
+        fun hasGetProviderNamesMethod() {
+            val method = BalanceProviderNotifier::class.java
+                .getDeclaredMethod("getProviderNames")
+            assertNotNull(method, "BalanceProviderNotifier should have getProviderNames() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProviderNotifier should have dispose method")
+        fun hasDisposeMethod() {
+            val method = BalanceProviderNotifier::class.java
+                .getDeclaredMethod("dispose")
+            assertNotNull(method, "BalanceProviderNotifier should have dispose() method")
+        }
+    }
+
+    @Nested
+    @DisplayName("BalanceProvider Interface Tests")
+    inner class BalanceProviderInterfaceTests {
+
+        @Test
+        @DisplayName("BalanceProvider should have onBalanceUpdated method")
+        fun hasOnBalanceUpdatedMethod() {
+            val method = BalanceProvider::class.java
+                .getDeclaredMethod("onBalanceUpdated", BalanceData::class.java)
+            assertNotNull(method, "BalanceProvider should have onBalanceUpdated() method")
+        }
+
+        @Test
+        @DisplayName("BalanceProvider should have onBalanceLoading method")
+        fun hasOnBalanceLoadingMethod() {
+            val method = BalanceProvider::class.java
+                .getDeclaredMethod("onBalanceLoading")
+            assertNotNull(method, "BalanceProvider should have onBalanceLoading() method")
+            // Kotlin default methods work - verified by MinimalProvider tests
+        }
+
+        @Test
+        @DisplayName("BalanceProvider should have onBalanceError method")
+        fun hasOnBalanceErrorMethod() {
+            val method = BalanceProvider::class.java
+                .getDeclaredMethod("onBalanceError", String::class.java)
+            assertNotNull(method, "BalanceProvider should have onBalanceError() method")
+            // Kotlin default methods work - verified by MinimalProvider tests
+        }
+    }
+
+    /**
+     * A test implementation of BalanceProvider for unit testing.
+     */
+    private class TestBalanceProvider : BalanceProvider {
+        var lastBalanceData: BalanceData? = null
+        var loadingCalled = false
+        var lastError: String? = null
+        var updateCount = 0
+
+        override fun onBalanceUpdated(data: BalanceData) {
+            lastBalanceData = data
+            updateCount++
+        }
+
+        override fun onBalanceLoading() {
+            loadingCalled = true
+        }
+
+        override fun onBalanceError(error: String) {
+            lastError = error
+        }
+
+        fun reset() {
+            lastBalanceData = null
+            loadingCalled = false
+            lastError = null
+            updateCount = 0
+        }
+    }
+
+    @Nested
+    @DisplayName("Mock Provider Tests")
+    inner class MockProviderTests {
+
+        @Test
+        @DisplayName("Test provider should receive balance updates")
+        fun testProviderReceivesUpdates() {
+            val provider = TestBalanceProvider()
+            val testData = createTestBalanceData()
+
+            provider.onBalanceUpdated(testData)
+
+            assertNotNull(provider.lastBalanceData)
+            assertEquals(testData, provider.lastBalanceData)
+            assertEquals(1, provider.updateCount)
+        }
+
+        @Test
+        @DisplayName("Test provider should receive loading notifications")
+        fun testProviderReceivesLoading() {
+            val provider = TestBalanceProvider()
+
+            assertFalse(provider.loadingCalled)
+            provider.onBalanceLoading()
+            assertTrue(provider.loadingCalled)
+        }
+
+        @Test
+        @DisplayName("Test provider should receive error notifications")
+        fun testProviderReceivesError() {
+            val provider = TestBalanceProvider()
+
+            val errorMessage = "Test error message"
+            provider.onBalanceError(errorMessage)
+
+            assertEquals(errorMessage, provider.lastError)
+        }
+
+        @Test
+        @DisplayName("Test provider should track multiple updates")
+        fun testProviderTracksMultipleUpdates() {
+            val provider = TestBalanceProvider()
+
+            repeat(5) {
+                provider.onBalanceUpdated(createTestBalanceData())
+            }
+
+            assertEquals(5, provider.updateCount)
+        }
+
+        @Test
+        @DisplayName("Test provider reset should clear state")
+        fun testProviderReset() {
+            val provider = TestBalanceProvider()
+
+            provider.onBalanceUpdated(createTestBalanceData())
+            provider.onBalanceLoading()
+            provider.onBalanceError("error")
+
+            provider.reset()
+
+            assertFalse(provider.loadingCalled)
+            assertEquals(null, provider.lastBalanceData)
+            assertEquals(null, provider.lastError)
+            assertEquals(0, provider.updateCount)
+        }
+
+        private fun createTestBalanceData(): BalanceData {
+            return BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+        }
+    }
+
+    /**
+     * A provider that throws exceptions for testing isolation.
+     */
+    private class ThrowingProvider : BalanceProvider {
+        override fun onBalanceUpdated(data: BalanceData) {
+            throw RuntimeException("Test exception from onBalanceUpdated")
+        }
+
+        override fun onBalanceLoading() {
+            throw RuntimeException("Test exception from onBalanceLoading")
+        }
+
+        override fun onBalanceError(error: String) {
+            throw RuntimeException("Test exception from onBalanceError")
+        }
+    }
+
+    @Nested
+    @DisplayName("Exception Handling Provider Tests")
+    inner class ExceptionHandlingTests {
+
+        @Test
+        @DisplayName("Throwing provider should not prevent interface implementation")
+        fun throwingProviderImplementsInterface() {
+            val provider = ThrowingProvider()
+            assertTrue(provider is BalanceProvider)
+        }
+
+        @Test
+        @DisplayName("Throwing provider onBalanceUpdated should throw expected exception")
+        fun throwingProviderThrows() {
+            val provider = ThrowingProvider()
+            val testData = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+
+            var exceptionThrown = false
+            try {
+                provider.onBalanceUpdated(testData)
+            } catch (e: RuntimeException) {
+                exceptionThrown = true
+                assertTrue(e.message?.contains("Test exception") == true)
+            }
+            assertTrue(exceptionThrown, "Expected RuntimeException to be thrown")
+        }
+    }
+
+    /**
+     * A minimal provider that only implements the required method.
+     */
+    private class MinimalProvider : BalanceProvider {
+        var lastData: BalanceData? = null
+
+        override fun onBalanceUpdated(data: BalanceData) {
+            lastData = data
+        }
+        // onBalanceLoading and onBalanceError use default implementations
+    }
+
+    @Nested
+    @DisplayName("Default Implementation Tests")
+    inner class DefaultImplementationTests {
+
+        @Test
+        @DisplayName("Minimal provider should work with default onBalanceLoading")
+        fun minimalProviderDefaultLoading() {
+            val provider = MinimalProvider()
+            // Should not throw - uses default empty implementation
+            provider.onBalanceLoading()
+        }
+
+        @Test
+        @DisplayName("Minimal provider should work with default onBalanceError")
+        fun minimalProviderDefaultError() {
+            val provider = MinimalProvider()
+            // Should not throw - uses default empty implementation
+            provider.onBalanceError("Test error")
+        }
+
+        @Test
+        @DisplayName("Minimal provider should receive balance updates")
+        fun minimalProviderReceivesUpdates() {
+            val provider = MinimalProvider()
+            val testData = BalanceData(
+                totalCredits = 100.0,
+                totalUsage = 25.0,
+                remainingCredits = 75.0,
+                timestamp = DEFAULT_TIMESTAMP
+            )
+
+            provider.onBalanceUpdated(testData)
+            assertEquals(testData, provider.lastData)
+        }
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/openrouter/services/settings/SetupStateManagerTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/services/settings/SetupStateManagerTest.kt
@@ -114,7 +114,7 @@ class SetupStateManagerTest {
             manager.setHasSeenWelcome(true)
             manager.setHasCompletedSetup(true)
             manager.setHasSeenWelcome(false)
-            
+
             assertEquals(3, stateChangedCount)
         }
 
@@ -122,7 +122,7 @@ class SetupStateManagerTest {
         fun `state is consistent after operations`() {
             manager.setHasSeenWelcome(true)
             manager.setHasCompletedSetup(true)
-            
+
             assertTrue(manager.hasSeenWelcome())
             assertTrue(manager.hasCompletedSetup())
         }

--- a/src/test/kotlin/org/zhavoronkov/openrouter/ui/SetupWizardErrorHandlerTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/ui/SetupWizardErrorHandlerTest.kt
@@ -177,7 +177,7 @@ class SetupWizardErrorHandlerTest {
         fun `creates error with friendly message`() {
             val originalError = ApiResult.Error("Missing Authentication header", 401)
             val result = SetupWizardErrorHandler.createValidationError(originalError)
-            
+
             assertEquals("Invalid key format or type", result.message)
             assertEquals(401, result.statusCode)
         }
@@ -186,7 +186,7 @@ class SetupWizardErrorHandlerTest {
         fun `preserves status code from original error`() {
             val originalError = ApiResult.Error("Network error", 503)
             val result = SetupWizardErrorHandler.createValidationError(originalError)
-            
+
             assertEquals(503, result.statusCode)
         }
 
@@ -195,7 +195,7 @@ class SetupWizardErrorHandlerTest {
             val throwable = RuntimeException("Original cause")
             val originalError = ApiResult.Error("Error", 500, throwable)
             val result = SetupWizardErrorHandler.createValidationError(originalError)
-            
+
             assertEquals(throwable, result.throwable)
         }
     }

--- a/src/test/kotlin/org/zhavoronkov/openrouter/ui/StatsDataLoaderTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/ui/StatsDataLoaderTest.kt
@@ -66,7 +66,7 @@ class StatsDataLoaderTest {
 
             // Should complete quickly since no async work needed
             latch.await(1, TimeUnit.SECONDS)
-            
+
             assertTrue(result is StatsDataLoader.LoadResult.Error)
             assertEquals("Failed to load data", (result as StatsDataLoader.LoadResult.Error).message)
         }
@@ -84,7 +84,7 @@ class StatsDataLoaderTest {
             }
 
             latch.await(1, TimeUnit.SECONDS)
-            
+
             assertTrue(result is StatsDataLoader.LoadResult.Error)
         }
     }


### PR DESCRIPTION
Introduces a new extension point that allows other plugins to receive OpenRouter balance data updates in real-time. This enables dependent plugins (like [Token Pulse](https://github.com/DimazzzZ/tokenpulse-intellij-plugin)) to display balance information without making duplicate API calls.

### Features
- **New `balanceProvider` Extension Point** - Plugins can register implementations to receive balance updates
- **`BalanceProvider` Interface** - Simple contract with `onBalanceUpdated()`, `onBalanceLoading()`, and `onBalanceError()` methods
- **`BalanceData` Data Class** - Immutable data transfer object with validation, formatting helpers, and derived calculations
- **User-Controllable Setting** - Toggle in Settings → Tools → OpenRouter to enable/disable balance sharing
- **Exception Isolation** - Misbehaving providers cannot crash the notification system

### Security Considerations
- Balance data is shared as immutable objects
- Individual provider exceptions are caught and logged without affecting other providers
- Users can disable the feature entirely via settings

### API Usage
Plugins can register their implementation in their `plugin.xml`:

```xml
<extensions defaultExtensionNs="org.zhavoronkov.openrouter">
    <balanceProvider implementation="com.example.MyBalanceProvider"/>
</extensions>
```

And implement the interface:

```kotlin
class MyBalanceProvider : BalanceProvider {
    override fun onBalanceUpdated(data: BalanceData) {
        // Handle balance update
    }
}
```

The `BalanceData` class provides the following information:

### Core Balance Data
| Property | Type | Description |
|----------|------|-------------|
| `totalCredits` | `Double` | Total credits purchased/available on the account |
| `totalUsage` | `Double` | Total credits consumed (all-time) |
| `remainingCredits` | `Double` | Credits remaining (`totalCredits - totalUsage`) |
| `timestamp` | `Long` | When the data was fetched (epoch millis) |
| `todayUsage` | `Double?` | Optional: Credits consumed today |

### Helper Methods
| Method | Returns | Description |
|--------|---------|-------------|
| `formattedTotalCredits()` | `String` | e.g., `"$100.00"` |
| `formattedTotalUsage()` | `String` | e.g., `"$25.00"` |
| `formattedRemaining()` | `String` | e.g., `"$75.00"` |
| `formattedTodayUsage()` | `String` | e.g., `"$5.00"` or `"N/A"` |
| `usagePercentage()` | `Double` | e.g., `25.0` (25% used) |
| `remainingPercentage()` | `Double` | e.g., `75.0` (75% remaining) |
| `isLowBalance()` | `Boolean` | `true` if remaining < 20% |
| `isCriticalBalance()` | `Boolean` | `true` if remaining < 5% |
| `formattedTimestamp()` | `String` | Human-readable date/time |

### Example Data
```kotlin
BalanceData(
    totalCredits = 100.0,      // $100 total
    totalUsage = 25.0,         // $25 used all-time
    remainingCredits = 75.0,   // $75 remaining
    timestamp = 1711526400000, // When fetched
    todayUsage = 3.50          // $3.50 used today
)
```

### Files Changed
- **New:** `api/BalanceProvider.kt`, `api/BalanceData.kt`, `services/BalanceProviderNotifier.kt`
- **Modified:** `plugin.xml`, `OpenRouterSettings.kt`, `UIPreferencesManager.kt`, `OpenRouterSettingsPanel.kt`, `OpenRouterConfigurable.kt`, `OpenRouterStatsCache.kt`
- **Tests:** `BalanceDataTest.kt`, `BalanceProviderNotifierTest.kt`, `BalanceProviderIntegrationTest.kt`

### Testing
- All existing tests pass
- 60+ new tests covering validation, calculations, formatting, and integration
- Detekt passes with no issues