### PR TITLE
Fix chat text copy/select support and migrate assistant rendering to Markdown HTML

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@ This guide covers development setup, building, testing, and contributing to the 
 ## 📋 Prerequisites
 
 ### Required Tools
-- **JDK 21 or higher** - Required for IntelliJ Platform 2024.2+ development
+- **JDK 21** - Required for IntelliJ Platform 2024.2+ development (JDK 26+ is not yet supported by the Kotlin compiler used in Gradle builds)
 - **IntelliJ IDEA** - Ultimate or Community Edition with Plugin Development support
 - **Git** - For version control and collaboration
 
@@ -31,8 +31,8 @@ cd openrouter-intellij-plugin
 # Make gradlew executable (Unix/macOS)
 chmod +x gradlew
 
-# Verify Java version
-java -version  # Should be JDK 17+
+# Verify Java version (must be JDK 21, not 26+)
+java -version  # Should be JDK 21
 ```
 
 ### 2. Build and Verify
@@ -148,6 +148,14 @@ pluginUntilBuild = 252.*      # IntelliJ 2025.2+
 
 #### Common Build Issues
 ```bash
+# JDK version mismatch (error: "What went wrong: 26")
+# The Kotlin compiler in Gradle may fail on JDK 26+. Use JDK 21:
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+./gradlew build --no-daemon
+
+# Or set in gradle.properties (uncomment and adjust path):
+# org.gradle.java.home=/path/to/zulu-21.jdk/Contents/Home
+
 # Configuration cache issues
 ./gradlew build --no-configuration-cache
 
@@ -467,7 +475,7 @@ curl -X POST http://localhost:8880/v1/chat/completions \
 - **Persistent Settings** - Tracks last seen version to prevent duplicate notifications
 
 ### Update Process
-```kotlin
+```text
 // Update version for new releases
 companion object {
     private const val CURRENT_VERSION = "0.3.0"  // ← Update for each release
@@ -725,7 +733,7 @@ Use this checklist when preparing a new version release:
 
 **File:** `src/main/kotlin/org/zhavoronkov/openrouter/startup/WhatsNewNotificationActivity.kt`
 
-```kotlin
+```text
 companion object {
     private const val CURRENT_VERSION = "0.3.0"  // ← Update this to new version
     private const val CHANGELOG_URL = "https://github.com/DimazzzZ/openrouter-intellij-plugin/blob/main/CHANGELOG.md"
@@ -742,7 +750,7 @@ companion object {
 
 Edit the `showWhatsNewNotification()` method to highlight the most important new features:
 
-```kotlin
+```text
 .createNotification(
     "OpenRouter Plugin Updated to v$CURRENT_VERSION",
     """
@@ -900,7 +908,7 @@ Before releasing, test that the notification works correctly:
 1. **Simulate upgrade from previous version:**
 
    Edit `src/main/kotlin/org/zhavoronkov/openrouter/models/OpenRouterModels.kt`:
-   ```kotlin
+   ```text
    var lastSeenVersion: String = "0.2.0"  // Simulate user on previous version
    ```
 
@@ -920,14 +928,14 @@ Before releasing, test that the notification works correctly:
    - [ ] Console shows: `"Showing What's New notification for version 0.3.0 (last seen: 0.2.0)"`
 
 5. **Revert the test change:**
-   ```kotlin
+   ```text
    var lastSeenVersion: String = ""  // Back to default
    ```
 
 ##### **Test Fresh Install (Should NOT Show Notification)**
 
 1. **Ensure default is empty:**
-   ```kotlin
+   ```text
    var lastSeenVersion: String = ""  // Default for fresh installs
    ```
 
@@ -1012,7 +1020,7 @@ Before publishing the new version:
 Here's a complete example of updating from 0.2.0 to 0.3.0:
 
 **1. WhatsNewNotificationActivity.kt:**
-```kotlin
+```text
 companion object {
     private const val CURRENT_VERSION = "0.3.0"  // Changed from "0.2.0"
     // ...

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,14 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.google.code.gson:gson:2.11.0")
 
+    // Markdown rendering (flexmark-java)
+    implementation("com.vladsch.flexmark:flexmark:0.64.8")
+    implementation("com.vladsch.flexmark:flexmark-util:0.64.8")
+    implementation("com.vladsch.flexmark:flexmark-ext-tables:0.64.8")
+    implementation("com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:0.64.8")
+    implementation("com.vladsch.flexmark:flexmark-ext-autolink:0.64.8")
+    implementation("com.vladsch.flexmark:flexmark-ext-gfm-tasklist:0.64.8")
+
     // Embedded HTTP server for AI Assistant integration (Jetty 12)
     implementation("org.eclipse.jetty:jetty-server:12.1.6")
     implementation("org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.6")

--- a/src/main/kotlin/org/zhavoronkov/openrouter/toolwindow/ChatPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/toolwindow/ChatPanel.kt
@@ -7,6 +7,7 @@ import com.google.gson.reflect.TypeToken
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.Project
+import com.intellij.ui.ColorUtil
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
@@ -714,22 +715,39 @@ class ChatPanel(
     }
 
     private fun addCompactMessage(message: String, isUser: Boolean) {
-        val rolePrefix = if (isUser) "You" else "Assistant"
-        val roleColor = if (isUser) "#6B9BD2" else "#9B9B9B"
+        val rolePrefix = if (isUser) "You:" else "Assistant:"
+        val roleColor = if (isUser) "#6B9BD2" else "#9B9BD2"
 
-        val escapedMessage = message
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace("\n", "<br>")
+        // Use a JPanel with role label and selectable text area
+        val messagePanel = JPanel(BorderLayout())
+        messagePanel.border = JBUI.Borders.empty(MESSAGE_BORDER_V, MESSAGE_BORDER_H)
+        messagePanel.alignmentX = JPanel.LEFT_ALIGNMENT
+        messagePanel.background = JBUI.CurrentTheme.ToolWindow.background()
 
-        val htmlContent = "<html><b style='color: $roleColor;'>$rolePrefix:</b> $escapedMessage</html>"
-        val contentLabel = JBLabel(htmlContent)
-        contentLabel.border = JBUI.Borders.empty(MESSAGE_BORDER_V, MESSAGE_BORDER_H)
-        contentLabel.verticalAlignment = JBLabel.TOP
-        contentLabel.alignmentX = JBLabel.LEFT_ALIGNMENT
+        // Role label (non-selectable prefix)
+        val roleLabel = JBLabel(rolePrefix)
+        roleLabel.foreground = ColorUtil.fromHex(roleColor)
+        roleLabel.border = JBUI.Borders.emptyRight(FLOW_LAYOUT_GAP)
+        roleLabel.verticalAlignment = JBLabel.TOP
 
-        messagesPanel.add(contentLabel)
+        // Selectable text area for the message body
+        val textArea = JBTextArea(message)
+        textArea.isEditable = false
+        textArea.lineWrap = true
+        textArea.wrapStyleWord = true
+        textArea.border = null
+        textArea.background = JBUI.CurrentTheme.ToolWindow.background()
+        textArea.foreground = JBUI.CurrentTheme.Label.foreground()
+        textArea.caret = javax.swing.text.DefaultCaret()
+        textArea.putClientProperty("caretWidth", 2)
+
+        // Set minimum height to at least fit one line
+        textArea.minimumSize = Dimension(100, textArea.preferredSize.height)
+
+        messagePanel.add(roleLabel, BorderLayout.WEST)
+        messagePanel.add(textArea, BorderLayout.CENTER)
+
+        messagesPanel.add(messagePanel)
         messagesPanel.revalidate()
         messagesPanel.repaint()
         scrollToBottom()

--- a/src/main/kotlin/org/zhavoronkov/openrouter/toolwindow/ChatPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/toolwindow/ChatPanel.kt
@@ -24,6 +24,7 @@ import org.zhavoronkov.openrouter.models.ChatMessage
 import org.zhavoronkov.openrouter.services.OpenRouterService
 import org.zhavoronkov.openrouter.services.OpenRouterSettingsService
 import org.zhavoronkov.openrouter.services.settings.PresetsManager
+import org.zhavoronkov.openrouter.utils.MarkdownRenderer
 import org.zhavoronkov.openrouter.utils.PluginLogger
 import java.awt.BorderLayout
 import java.awt.CardLayout
@@ -42,10 +43,11 @@ import java.util.Date
 import java.util.UUID
 import javax.swing.BoxLayout
 import javax.swing.DefaultComboBoxModel
+import javax.swing.JEditorPane
 import javax.swing.DefaultListCellRenderer
 import javax.swing.DefaultListModel
 import javax.swing.JButton
-import javax.swing.JComboBox
+import com.intellij.openapi.ui.ComboBox
 import javax.swing.JList
 import javax.swing.JMenuItem
 import javax.swing.JOptionPane
@@ -101,7 +103,7 @@ class ChatPanel(
     private lateinit var messagesScrollPane: JBScrollPane
     private val inputArea: JBTextArea
     private val sendButton: JButton
-    private val modelComboBox: JComboBox<String>
+    private val modelComboBox: ComboBox<String>
     private val statusLabel: JBLabel
     private val inputTokensLabel: JBLabel
 
@@ -120,7 +122,7 @@ class ChatPanel(
         inputTokensLabel = JBLabel("~0 tokens")
         inputArea = JBTextArea(INPUT_ROWS, INPUT_COLUMNS)
         sendButton = JButton("Send")
-        modelComboBox = JComboBox()
+        modelComboBox = ComboBox<String>()
         chatList = JBList(chatListModel)
 
         // Create main panel with CardLayout
@@ -730,22 +732,50 @@ class ChatPanel(
         roleLabel.border = JBUI.Borders.emptyRight(FLOW_LAYOUT_GAP)
         roleLabel.verticalAlignment = JBLabel.TOP
 
-        // Selectable text area for the message body
-        val textArea = JBTextArea(message)
-        textArea.isEditable = false
-        textArea.lineWrap = true
-        textArea.wrapStyleWord = true
-        textArea.border = null
-        textArea.background = JBUI.CurrentTheme.ToolWindow.background()
-        textArea.foreground = JBUI.CurrentTheme.Label.foreground()
-        textArea.caret = javax.swing.text.DefaultCaret()
-        textArea.putClientProperty("caretWidth", 2)
+        // Use same UI font for both message types to avoid font mismatch
+        val uiFont = inputArea.font ?: JBLabel().font
+        val uiForeground = JBUI.CurrentTheme.Label.foreground()
+        val uiBackground = JBUI.CurrentTheme.ToolWindow.background()
 
-        // Set minimum height to at least fit one line
-        textArea.minimumSize = Dimension(100, textArea.preferredSize.height)
-
-        messagePanel.add(roleLabel, BorderLayout.WEST)
-        messagePanel.add(textArea, BorderLayout.CENTER)
+        if (!isUser) {
+            // Assistant: render Markdown to HTML using JEditorPane
+            // Use role prefix inside HTML to ensure inline rendering with colored label
+            val htmlContent = MarkdownRenderer.wrapInHtmlDocumentWithRolePrefix(
+                bodyHtml = MarkdownRenderer.renderToHtml(message),
+                rolePrefix = rolePrefix,
+                roleColorHex = roleColor,
+                fontFamily = uiFont.family,
+                fontSizePx = uiFont.size,
+                contentColorHex = ColorUtil.toHex(uiForeground)
+            )
+            val textPane = JEditorPane("text/html", htmlContent)
+            textPane.isEditable = false
+            textPane.border = null
+            textPane.margin = JBUI.emptyInsets()
+            textPane.background = uiBackground
+            textPane.font = uiFont
+            textPane.foreground = uiForeground
+            // Force JEditorPane to honor display properties for HTML content
+            textPane.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true)
+            textPane.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, true)
+            messagePanel.add(textPane, BorderLayout.CENTER)
+        } else {
+            // User: plain text in JBTextArea
+            val textArea = JBTextArea(message)
+            textArea.isEditable = false
+            textArea.lineWrap = true
+            textArea.wrapStyleWord = true
+            textArea.border = null
+            textArea.background = uiBackground
+            textArea.foreground = uiForeground
+            textArea.font = uiFont
+            textArea.caret = javax.swing.text.DefaultCaret()
+            textArea.putClientProperty("caretWidth", 2)
+            // Set minimum height to at least fit one line
+            textArea.minimumSize = Dimension(100, textArea.preferredSize.height)
+            messagePanel.add(roleLabel, BorderLayout.WEST)
+            messagePanel.add(textArea, BorderLayout.CENTER)
+        }
 
         messagesPanel.add(messagePanel)
         messagesPanel.revalidate()

--- a/src/main/kotlin/org/zhavoronkov/openrouter/toolwindow/ChatPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/toolwindow/ChatPanel.kt
@@ -7,6 +7,7 @@ import com.google.gson.reflect.TypeToken
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.ColorUtil
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
@@ -43,11 +44,10 @@ import java.util.Date
 import java.util.UUID
 import javax.swing.BoxLayout
 import javax.swing.DefaultComboBoxModel
-import javax.swing.JEditorPane
 import javax.swing.DefaultListCellRenderer
 import javax.swing.DefaultListModel
 import javax.swing.JButton
-import com.intellij.openapi.ui.ComboBox
+import javax.swing.JEditorPane
 import javax.swing.JList
 import javax.swing.JMenuItem
 import javax.swing.JOptionPane
@@ -80,6 +80,7 @@ class ChatPanel(
         private const val CHARS_PER_TOKEN = 4.0
         private const val CARD_LIST = "list"
         private const val CARD_CHAT = "chat"
+        private const val MIN_TEXT_AREA_WIDTH = 100
         private const val HEADER_FONT_SIZE_INCREASE = 2f
         private const val FLOW_LAYOUT_GAP = 4
         private const val COMBO_BOX_WIDTH = 180
@@ -772,7 +773,7 @@ class ChatPanel(
             textArea.caret = javax.swing.text.DefaultCaret()
             textArea.putClientProperty("caretWidth", 2)
             // Set minimum height to at least fit one line
-            textArea.minimumSize = Dimension(100, textArea.preferredSize.height)
+            textArea.minimumSize = Dimension(MIN_TEXT_AREA_WIDTH, textArea.preferredSize.height)
             messagePanel.add(roleLabel, BorderLayout.WEST)
             messagePanel.add(textArea, BorderLayout.CENTER)
         }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRenderer.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRenderer.kt
@@ -1,0 +1,138 @@
+package org.zhavoronkov.openrouter.utils
+
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
+import com.vladsch.flexmark.ext.tables.TablesExtension
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.ast.Document
+import com.vladsch.flexmark.util.data.MutableDataSet
+
+/**
+ * Renders Markdown text to HTML for display in Swing components.
+ * Supports: headings, bold, italic, strikethrough, code (inline + fenced blocks),
+ * links, lists, blockquotes, tables, and task lists.
+ */
+@Suppress("unused")
+object MarkdownRenderer {
+    private val options: MutableDataSet by lazy {
+        MutableDataSet().apply {
+            set(Parser.EXTENSIONS, listOf(
+                TablesExtension.create(),
+                StrikethroughExtension.create(),
+                AutolinkExtension.create(),
+                TaskListExtension.create()
+            ))
+            set(HtmlRenderer.SOFT_BREAK, "<br/>\n")
+        }
+    }
+
+    private val parser: Parser by lazy { Parser.builder(options).build() }
+    private val renderer: HtmlRenderer by lazy { HtmlRenderer.builder(options).build() }
+
+    /**
+     * Render Markdown text to HTML string.
+     *
+     * @param markdown Raw Markdown input (from LLM)
+     * @return HTML string suitable for JEditorPane display
+     */
+    fun renderToHtml(markdown: String): String {
+        if (markdown.isBlank()) return ""
+        val document: Document = parser.parse(markdown)
+        val html = renderer.render(document)
+        return normalizeForInlineDisplay(html)
+    }
+
+    /**
+     * Normalize rendered HTML so that short assistant messages
+     * render inline next to the "Assistant:" label without a line break.
+     *
+     * - Single <p>...</p> blocks are unwrapped to inline content
+     * - Multi-paragraph content keeps structure but gets zero top margin on first <p>
+     */
+    private fun normalizeForInlineDisplay(html: String): String {
+        if (html.isBlank()) return html
+
+        // Check if the entire content is EXACTLY one <p> block (no other tags except inline ones inside)
+        // Must match the whole string from start to end
+        val singleParagraphRegex = Regex("""^<p>(.*)</p>$""", RegexOption.DOT_MATCHES_ALL)
+        val match = singleParagraphRegex.matchEntire(html)
+
+        return if (match != null) {
+            // Unwrap single paragraph - return just the inline content
+            match.groupValues[1]
+        } else {
+            // Multi-paragraph or complex content: normalize all paragraph margins
+            html.replace(
+                Regex("""<p([^>]*)>"""),
+                """<p$1 style="margin-top: 0; margin-bottom: 0;">"""
+            )
+        }
+    }
+
+    /**
+     * Wrap HTML content with a colored role prefix (e.g., "Assistant:").
+     * The prefix is rendered as inline HTML with the specified color.
+     *
+     * @param bodyHtml HTML body content
+     * @param rolePrefix The role prefix text (e.g., "Assistant:")
+     * @param roleColorHex Color for the role prefix (e.g., "#9B9BD2")
+     * @param fontFamily Font family
+     * @param fontSizePx Font size in pixels
+     * @param contentColorHex Color for the message content
+     * @return Complete HTML document string
+     */
+    fun wrapInHtmlDocumentWithRolePrefix(
+        bodyHtml: String,
+        rolePrefix: String,
+        roleColorHex: String,
+        fontFamily: String,
+        fontSizePx: Int,
+        contentColorHex: String
+    ): String {
+        return buildString {
+            append("<html><body style='margin: 0; padding: 0; font-family: $fontFamily; font-size: ${fontSizePx}px;'>")
+            append("<span style='color: $roleColorHex; font-weight: bold;'>$rolePrefix</span> ")
+            append("<span style='color: $contentColorHex;'>$bodyHtml</span>")
+            append("</body></html>")
+        }
+    }
+
+    /**
+     * Wrap HTML content in a minimal document with optional font styling.
+     *
+     * Note: JEditorPane's Swing HTML parser crashes on complex embedded CSS
+     * (NPE in CSS.getInternalCSSValue), so we return minimal HTML with only
+     * inline styles for font/color to avoid the crash.
+     *
+     * @param bodyHtml HTML body content (output of [renderToHtml])
+     * @param fontFamily Optional font family to apply
+     * @param fontSizePx Optional font size in pixels
+     * @param colorHex Optional color in hex format (e.g., "#000000")
+     * @param isUser True if this is a user message
+     * @return Complete HTML document string
+     */
+    fun wrapInHtmlDocument(
+        bodyHtml: String,
+        fontFamily: String? = null,
+        fontSizePx: Int? = null,
+        colorHex: String? = null,
+        isUser: Boolean = false
+    ): String {
+        val styleBuilder = StringBuilder()
+        styleBuilder.append("margin: 0; padding: 0; ")
+        fontFamily?.let { styleBuilder.append("font-family: $it; ") }
+        fontSizePx?.let { styleBuilder.append("font-size: ${it}px; ") }
+        colorHex?.let { styleBuilder.append("color: $it; ") }
+        
+        val styleAttr = styleBuilder.toString().trim()
+        val bodyStyle = if (styleAttr.isNotEmpty()) " style='$styleAttr'" else ""
+        
+        return buildString {
+            append("<html><body$bodyStyle>")
+            append(bodyHtml)
+            append("</body></html>")
+        }
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRenderer.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRenderer.kt
@@ -18,12 +18,15 @@ import com.vladsch.flexmark.util.data.MutableDataSet
 object MarkdownRenderer {
     private val options: MutableDataSet by lazy {
         MutableDataSet().apply {
-            set(Parser.EXTENSIONS, listOf(
-                TablesExtension.create(),
-                StrikethroughExtension.create(),
-                AutolinkExtension.create(),
-                TaskListExtension.create()
-            ))
+            set(
+                Parser.EXTENSIONS,
+                listOf(
+                    TablesExtension.create(),
+                    StrikethroughExtension.create(),
+                    AutolinkExtension.create(),
+                    TaskListExtension.create(),
+                )
+            )
             set(HtmlRenderer.SOFT_BREAK, "<br/>\n")
         }
     }
@@ -83,6 +86,7 @@ object MarkdownRenderer {
      * @param contentColorHex Color for the message content
      * @return Complete HTML document string
      */
+    @Suppress("LongParameterList")
     fun wrapInHtmlDocumentWithRolePrefix(
         bodyHtml: String,
         rolePrefix: String,
@@ -125,10 +129,9 @@ object MarkdownRenderer {
         fontFamily?.let { styleBuilder.append("font-family: $it; ") }
         fontSizePx?.let { styleBuilder.append("font-size: ${it}px; ") }
         colorHex?.let { styleBuilder.append("color: $it; ") }
-        
         val styleAttr = styleBuilder.toString().trim()
         val bodyStyle = if (styleAttr.isNotEmpty()) " style='$styleAttr'" else ""
-        
+
         return buildString {
             append("<html><body$bodyStyle>")
             append(bodyHtml)

--- a/src/test/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRendererTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRendererTest.kt
@@ -1,0 +1,254 @@
+package org.zhavoronkov.openrouter.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for MarkdownRenderer utility
+ */
+@DisplayName("MarkdownRenderer Tests")
+class MarkdownRendererTest {
+
+    @Nested
+    @DisplayName("Markdown to HTML Rendering")
+    inner class MarkdownToHtmlTests {
+
+        @Test
+        @DisplayName("Should render bold text")
+        fun `Should render bold text`() {
+            val html = MarkdownRenderer.renderToHtml("This is **bold** text")
+            assertTrue(html.contains("<strong>bold</strong>") || html.contains("<b>bold</b>"), "Should contain bold tags")
+        }
+
+        @Test
+        @DisplayName("Should render italic text")
+        fun `Should render italic text`() {
+            val html = MarkdownRenderer.renderToHtml("This is *italic* text")
+            assertTrue(html.contains("<em>italic</em>") || html.contains("<i>italic</i>"), "Should contain italic tags")
+        }
+
+        @Test
+        @DisplayName("Should render inline code")
+        fun `Should render inline code`() {
+            val html = MarkdownRenderer.renderToHtml("This is `code` text")
+            assertTrue(html.contains("<code>"), "Should contain code tags")
+        }
+
+        @Test
+        @DisplayName("Should render fenced code blocks")
+        fun `Should render fenced code blocks`() {
+            val markdown = """
+                Here is some code:
+                ```python
+                def hello():
+                    print("Hello")
+                ```
+            """.trimIndent()
+            val html = MarkdownRenderer.renderToHtml(markdown)
+            assertTrue(html.contains("<pre"), "Should contain pre tags for code blocks")
+            assertTrue(html.contains("def hello()"), "Should contain code content")
+        }
+
+        @Test
+        @DisplayName("Should render links")
+        fun `Should render links`() {
+            val html = MarkdownRenderer.renderToHtml("Check [this link](https://example.com)")
+            assertTrue(html.contains("<a href="), "Should contain anchor tags")
+            assertTrue(html.contains("https://example.com"), "Should contain href")
+        }
+
+        @Test
+        @DisplayName("Should render strikethrough")
+        fun `Should render strikethrough`() {
+            val html = MarkdownRenderer.renderToHtml("This is ~~deleted~~ text")
+            assertTrue(html.contains("<del>") || html.contains("<s>") || html.contains("<strike>"), "Should contain strikethrough tags")
+        }
+
+        @Test
+        @DisplayName("Should render tables")
+        fun `Should render tables`() {
+            val markdown = """
+                | Header 1 | Header 2 |
+                |----------|----------|
+                | Cell 1   | Cell 2   |
+            """.trimIndent()
+            val html = MarkdownRenderer.renderToHtml(markdown)
+            assertTrue(html.contains("<table>"), "Should contain table tags")
+            assertTrue(html.contains("<th>"), "Should contain th tags")
+            assertTrue(html.contains("<td>"), "Should contain td tags")
+        }
+
+        @Test
+        @DisplayName("Should render task lists")
+        fun `Should render task lists`() {
+            val markdown = """
+                - [ ] Unchecked task
+                - [x] Checked task
+            """.trimIndent()
+            val html = MarkdownRenderer.renderToHtml(markdown)
+            assertTrue(html.contains("checkbox"), "Should contain checkbox input")
+        }
+
+        @Test
+        @DisplayName("Should render headings")
+        fun `Should render headings`() {
+            val html = MarkdownRenderer.renderToHtml("# Heading 1\n## Heading 2\n### Heading 3")
+            assertTrue(html.contains("<h1>"), "Should contain h1 tag")
+            assertTrue(html.contains("<h2>"), "Should contain h2 tag")
+            assertTrue(html.contains("<h3>"), "Should contain h3 tag")
+        }
+
+        @Test
+        @DisplayName("Should render blockquotes")
+        fun `Should render blockquotes`() {
+            val html = MarkdownRenderer.renderToHtml("> This is a quote")
+            assertTrue(html.contains("<blockquote>"), "Should contain blockquote tags")
+        }
+
+        @Test
+        @DisplayName("Should handle empty string")
+        fun `Should handle empty string`() {
+            val html = MarkdownRenderer.renderToHtml("")
+            assertEquals("", html, "Empty input should return empty output")
+        }
+
+        @Test
+        @DisplayName("Should handle plain text without markdown")
+        fun `Should handle plain text without markdown`() {
+            val html = MarkdownRenderer.renderToHtml("Just plain text here")
+            assertTrue(html.contains("Just plain text here"), "Should contain the plain text")
+        }
+
+        @Test
+        @DisplayName("Should unwrap single paragraph for inline display")
+        fun `Should unwrap single paragraph for inline display`() {
+            val html = MarkdownRenderer.renderToHtml("Hello world")
+            // Single paragraph should be unwrapped so it renders inline next to "Assistant:"
+            assertFalse(html.startsWith("<p>"), "Should not start with <p> tag")
+            assertFalse(html.endsWith("</p>"), "Should not end with </p> tag")
+            assertTrue(html.contains("Hello world"), "Should contain the text")
+        }
+
+        @Test
+        @DisplayName("Should normalize margins for multi-paragraph content")
+        fun `Should normalize margins for multi-paragraph content`() {
+            val html = MarkdownRenderer.renderToHtml("First paragraph.\n\nSecond paragraph.")
+            assertTrue(html.contains("<p"), "Should contain paragraph tags, got: $html")
+            // Check for margin normalization on paragraphs
+            assertTrue(html.contains("margin-top: 0"), "Should have margin-top: 0 on paragraphs, got: $html")
+        }
+
+        @Test
+        @DisplayName("Should render unordered lists")
+        fun `Should render unordered lists`() {
+            val html = MarkdownRenderer.renderToHtml("- Item 1\n- Item 2\n- Item 3")
+            assertTrue(html.contains("<ul>"), "Should contain ul tags")
+            assertTrue(html.contains("<li>"), "Should contain li tags")
+        }
+
+        @Test
+        @DisplayName("Should render ordered lists")
+        fun `Should render ordered lists`() {
+            val html = MarkdownRenderer.renderToHtml("1. First\n2. Second\n3. Third")
+            assertTrue(html.contains("<ol>"), "Should contain ol tags")
+            assertTrue(html.contains("<li>"), "Should contain li tags")
+        }
+
+        @Test
+        @DisplayName("Should render horizontal rules")
+        fun `Should render horizontal rules`() {
+            val html = MarkdownRenderer.renderToHtml("Text\n\n---\n\nMore text")
+            assertTrue(html.contains("<hr"), "Should contain hr tag")
+        }
+    }
+
+    @Nested
+    @DisplayName("HTML Document Wrapping")
+    inner class HtmlDocumentTests {
+
+        @Test
+        @DisplayName("Should wrap HTML in minimal document")
+        fun `Should wrap HTML in minimal document`() {
+            val bodyHtml = "<p>Hello World</p>"
+            val document = MarkdownRenderer.wrapInHtmlDocument(bodyHtml, isUser = false)
+            assertTrue(document.contains("<html>"), "Should contain html tags")
+            assertTrue(document.contains("<body"), "Should contain body tags")
+            assertTrue(document.contains("<p>Hello World</p>"), "Should contain original body content")
+        }
+
+        @Test
+        @DisplayName("Should apply font styling when provided")
+        fun `Should apply font styling when provided`() {
+            val document = MarkdownRenderer.wrapInHtmlDocument(
+                "<p>Test</p>",
+                fontFamily = "JetBrains Mono",
+                fontSizePx = 13,
+                colorHex = "#000000"
+            )
+            assertTrue(document.contains("margin: 0; padding: 0;"), "Should contain margin/padding reset")
+            assertTrue(document.contains("font-family: JetBrains Mono"), "Should contain font-family")
+            assertTrue(document.contains("font-size: 13px"), "Should contain font-size")
+            assertTrue(document.contains("color: #000000"), "Should contain color")
+        }
+
+        @Test
+        @DisplayName("Should not include style block when no font args")
+        fun `Should not include style block when no font args`() {
+            val document = MarkdownRenderer.wrapInHtmlDocument("<p>Test</p>")
+            assertFalse(document.contains("<style>"), "Should not contain style block")
+            assertFalse(document.contains("<head>"), "Should not contain head block")
+        }
+
+        @Test
+        @DisplayName("Should handle empty body with font styling")
+        fun `Should handle empty body with font styling`() {
+            val document = MarkdownRenderer.wrapInHtmlDocument(
+                "",
+                fontFamily = "Arial",
+                fontSizePx = 14
+            )
+            assertTrue(document.contains("<html>"), "Should contain html")
+            assertTrue(document.contains("font-family: Arial"), "Should contain font-family")
+        }
+    }
+
+    @Nested
+    @DisplayName("HTML Document with Role Prefix")
+    inner class HtmlDocumentWithRolePrefixTests {
+
+        @Test
+        @DisplayName("Should wrap HTML with role prefix")
+        fun `Should wrap HTML with role prefix`() {
+            val document = MarkdownRenderer.wrapInHtmlDocumentWithRolePrefix(
+                bodyHtml = "Hello world",
+                rolePrefix = "Assistant:",
+                roleColorHex = "#9B9BD2",
+                fontFamily = "JetBrains Mono",
+                fontSizePx = 13,
+                contentColorHex = "#000000"
+            )
+            assertTrue(document.contains("Assistant:"), "Should contain role prefix")
+            assertTrue(document.contains("color: #9B9BD2"), "Should contain role color")
+            assertTrue(document.contains("Hello world"), "Should contain body content")
+        }
+
+        @Test
+        @DisplayName("Should apply font styling")
+        fun `Should apply font styling`() {
+            val document = MarkdownRenderer.wrapInHtmlDocumentWithRolePrefix(
+                bodyHtml = "Test",
+                rolePrefix = "You:",
+                roleColorHex = "#6B9BD2",
+                fontFamily = "Arial",
+                fontSizePx = 14,
+                contentColorHex = "#333333"
+            )
+            assertTrue(document.contains("font-family: Arial"), "Should contain font-family")
+            assertTrue(document.contains("font-size: 14px"), "Should contain font-size")
+        }
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRendererTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRendererTest.kt
@@ -21,7 +21,10 @@ class MarkdownRendererTest {
         @DisplayName("Should render bold text")
         fun `Should render bold text`() {
             val html = MarkdownRenderer.renderToHtml("This is **bold** text")
-            assertTrue(html.contains("<strong>bold</strong>") || html.contains("<b>bold</b>"), "Should contain bold tags")
+            assertTrue(
+                html.contains("<strong>bold</strong>") || html.contains("<b>bold</b>"),
+                "Should contain bold tags"
+            )
         }
 
         @Test
@@ -65,7 +68,10 @@ class MarkdownRendererTest {
         @DisplayName("Should render strikethrough")
         fun `Should render strikethrough`() {
             val html = MarkdownRenderer.renderToHtml("This is ~~deleted~~ text")
-            assertTrue(html.contains("<del>") || html.contains("<s>") || html.contains("<strike>"), "Should contain strikethrough tags")
+            assertTrue(
+                html.contains("<del>") || html.contains("<s>") || html.contains("<strike>"),
+                "Should contain strikethrough tags"
+            )
         }
 
         @Test
@@ -229,7 +235,7 @@ class MarkdownRendererTest {
                 roleColorHex = "#9B9BD2",
                 fontFamily = "JetBrains Mono",
                 fontSizePx = 13,
-                contentColorHex = "#000000"
+                contentColorHex = "#000000",
             )
             assertTrue(document.contains("Assistant:"), "Should contain role prefix")
             assertTrue(document.contains("color: #9B9BD2"), "Should contain role color")


### PR DESCRIPTION
### Summary
This PR fixes the chat UX issue where assistant output in WebStorm/IntelliJ could not be selected or copied. It migrates assistant message rendering to HTML via `JEditorPane` + `flexmark`, keeps user messages in plain `JBTextArea`, and normalizes font/spacing behavior so chat remains readable and consistent.

### Problem
- Assistant chat output was not selectable/copyable.
- Earlier HTML/CSS attempts caused Swing parser instability (`JEditorPane` CSS parsing issues).
- Assistant label/message alignment had line-break/layout inconsistencies.
- A few IntelliJ inspections remained in `ChatPanel.kt` and `DEVELOPMENT.md`.

### What changed
- **Markdown rendering pipeline**
  - Added `MarkdownRenderer` utility with `flexmark-java`.
  - Added support for common markdown features (tables, autolinks, strikethrough, task lists, etc.).
  - Normalized HTML output for inline display in chat.
- **Chat UI rendering updates (`ChatPanel.kt`)**
  - Assistant messages now render through `JEditorPane("text/html", ...)`.
  - Role prefix is rendered inline in HTML for consistent one-line start (`Assistant: ...`).
  - Font/display properties are explicitly honored for better consistency.
  - Replaced Swing `JComboBox` with IntelliJ `ComboBox`.
  - Replaced inset creation with DPI-aware `JBUI.emptyInsets()`.
- **Build/dependency updates**
  - Added `flexmark` dependencies in `build.gradle.kts`.
- **Tests**
  - Added comprehensive `MarkdownRendererTest` coverage (rendering + wrappers + role prefix behavior).
- **Docs/IDE warning cleanup**
  - Updated `DEVELOPMENT.md` (JDK guidance and code-fence cleanup for snippet sections that are not complete Kotlin programs).

### Files changed
- `build.gradle.kts`
- `src/main/kotlin/org/zhavoronkov/openrouter/toolwindow/ChatPanel.kt`
- `src/main/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRenderer.kt` (new)
- `src/test/kotlin/org/zhavoronkov/openrouter/utils/MarkdownRendererTest.kt`
- `DEVELOPMENT.md`

### Validation
- ✅ `./gradlew build --no-daemon` (JDK 21) passes
- ✅ Markdown renderer tests pass
- ✅ Assistant output is selectable/copyable
- ✅ Assistant prefix/message start alignment improved
