### PR TITLE
feat: show total models count in favorite models settings with output_modalities=all

### DIFF
--- a/src/main/kotlin/org/zhavoronkov/openrouter/models/OpenRouterModels.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/models/OpenRouterModels.kt
@@ -123,6 +123,15 @@ data class OpenRouterModelsResponse(
     val data: List<OpenRouterModelInfo>
 )
 
+// OpenRouter Models Count API Response
+data class ModelsCountResponse(
+    val data: ModelsCountData
+)
+
+data class ModelsCountData(
+    val count: Int
+)
+
 data class OpenRouterModelInfo(
     val id: String,
     val name: String,

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/FavoriteModelsService.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/FavoriteModelsService.kt
@@ -8,6 +8,7 @@ import org.zhavoronkov.openrouter.constants.OpenRouterConstants
 import org.zhavoronkov.openrouter.models.ApiResult
 import org.zhavoronkov.openrouter.models.OpenRouterModelInfo
 import org.zhavoronkov.openrouter.utils.PluginLogger
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Service for managing favorite models with caching and API interaction
@@ -53,7 +54,7 @@ class FavoriteModelsService(
 
         PluginLogger.Service.debug("[OpenRouter] Fetching models from API (forceRefresh: $forceRefresh)")
         return try {
-            withTimeout(OpenRouterConstants.API_TIMEOUT_MS) {
+            withTimeout(OpenRouterConstants.API_TIMEOUT_MS.milliseconds) {
                 val result = routerService.getModels()
                 when (result) {
                     is ApiResult.Success -> {
@@ -198,6 +199,13 @@ class FavoriteModelsService(
         cachedModels = null
         cacheTimestamp = 0L
         PluginLogger.Service.debug("Models cache cleared")
+    }
+
+    /**
+     * Get the OpenRouter service instance for direct API calls
+     */
+    fun getOpenRouterService(): OpenRouterService {
+        return routerService
     }
 
     /**

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/FavoriteModelsService.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/FavoriteModelsService.kt
@@ -202,10 +202,34 @@ class FavoriteModelsService(
     }
 
     /**
-     * Get the OpenRouter service instance for direct API calls
+     * Get total count of available models from OpenRouter
+     * Uses output_modalities=all to include all model types (not just text)
      */
-    fun getOpenRouterService(): OpenRouterService {
-        return routerService
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun getModelsCount(): Int? {
+        return try {
+            PluginLogger.Settings.debug("Fetching models count from /models/count?output_modalities=all")
+            val result = routerService.getModelsCount()
+            when (result) {
+                is ApiResult.Success -> {
+                    val count = result.data.data.count
+                    PluginLogger.Settings.debug("Successfully fetched models count: $count")
+                    count
+                }
+                is ApiResult.Error -> {
+                    PluginLogger.Settings.warn(
+                        "Failed to fetch models count: ${result.message} (statusCode=${result.statusCode})"
+                    )
+                    null
+                }
+            }
+        } catch (e: java.io.IOException) {
+            PluginLogger.Settings.warn("Network error fetching models count: ${e.message}")
+            null
+        } catch (e: Throwable) {
+            PluginLogger.Settings.warn("Unexpected error fetching models count: ${e.message}")
+            null
+        }
     }
 
     /**

--- a/src/main/kotlin/org/zhavoronkov/openrouter/services/OpenRouterService.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/services/OpenRouterService.kt
@@ -23,6 +23,7 @@ import org.zhavoronkov.openrouter.models.ExchangeAuthCodeResponse
 import org.zhavoronkov.openrouter.models.GenerationResponse
 import org.zhavoronkov.openrouter.models.KeyData
 import org.zhavoronkov.openrouter.models.KeyInfoResponse
+import org.zhavoronkov.openrouter.models.ModelsCountResponse
 import org.zhavoronkov.openrouter.models.OpenRouterModelsResponse
 import org.zhavoronkov.openrouter.models.OpenRouterResponse
 import org.zhavoronkov.openrouter.models.ProvidersResponse
@@ -88,6 +89,7 @@ open class OpenRouterService(
     private fun getAuthKeysEndpoint() = "${getBaseUrl()}/auth/keys"
     private fun getProvidersEndpoint() = "${getBaseUrl()}/providers"
     private fun getModelsEndpoint() = "${getBaseUrl()}/models"
+    private fun getModelsCountEndpoint() = "${getBaseUrl()}/models/count"
 
     /**
      * Handle network errors gracefully without alarming users
@@ -583,6 +585,21 @@ open class OpenRouterService(
             "Error fetching models"
         ) { responseBody ->
             gson.fromJson(responseBody, OpenRouterModelsResponse::class.java)
+        }
+
+    /**
+     * Get total count of available models from OpenRouter
+     * Uses output_modalities=all to include all model types (not just text)
+     * NOTE: This is a public endpoint that requires no authentication
+     */
+    suspend fun getModelsCount(): ApiResult<ModelsCountResponse> =
+        fetchPublicEndpoint(
+            "${getModelsCountEndpoint()}?output_modalities=all",
+            "models count",
+            OpenRouterConstants.RESPONSE_PREVIEW_LENGTH_SMALL,
+            "Error fetching models count"
+        ) { responseBody ->
+            gson.fromJson(responseBody, ModelsCountResponse::class.java)
         }
 
     /**

--- a/src/main/kotlin/org/zhavoronkov/openrouter/settings/FavoriteModelsSettingsPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/settings/FavoriteModelsSettingsPanel.kt
@@ -24,6 +24,8 @@ import com.intellij.util.ui.ListTableModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.zhavoronkov.openrouter.models.OpenRouterModelInfo
 import org.zhavoronkov.openrouter.services.FavoriteModelsService
 import org.zhavoronkov.openrouter.services.OpenRouterSettingsService
@@ -97,6 +99,7 @@ class FavoriteModelsSettingsPanel : Disposable {
     private var loadError: String? = null
     private var allAvailableModels: List<OpenRouterModelInfo> = emptyList()
     private var filteredAvailableModels: List<OpenRouterModelInfo> = emptyList()
+    private var totalModelsCount: Int = 0
     private var initialFavorites: List<String> = emptyList()
     private var availableStatusLabel: javax.swing.JLabel? = null
     private var favoritesStatusLabel: javax.swing.JLabel? = null
@@ -192,6 +195,9 @@ class FavoriteModelsSettingsPanel : Disposable {
             onModelsLoaded = ::handleModelsLoaded,
             onLoadError = ::handleLoadError
         )
+
+        // Fetch total models count from /models/count endpoint
+        loadTotalModelsCount()
 
         val filterComponents = FilterComponents(
             searchField = searchField,
@@ -603,6 +609,27 @@ class FavoriteModelsSettingsPanel : Disposable {
     }
 
     /**
+     * Load total models count from /models/count?output_modalities=all
+     */
+    private fun loadTotalModelsCount() {
+        coroutineScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                favoriteModelsService.getOpenRouterService().getModelsCount()
+            }
+            when (result) {
+                is org.zhavoronkov.openrouter.models.ApiResult.Success -> {
+                    totalModelsCount = result.data.data.count
+                    PluginLogger.Settings.debug("Total models count: $totalModelsCount")
+                    updateStatusLabels()
+                }
+                is org.zhavoronkov.openrouter.models.ApiResult.Error -> {
+                    PluginLogger.Settings.debug("Failed to fetch total models count: ${result.message}")
+                }
+            }
+        }
+    }
+
+    /**
      * Refresh available models from API (bypass cache)
      */
     private fun refreshAvailableModels() {
@@ -762,6 +789,7 @@ class FavoriteModelsSettingsPanel : Disposable {
             loadError != null -> "Error: $loadError"
             filteredAvailableModels.isEmpty() && searchField.text.isNotBlank() -> "No models match search"
             filteredAvailableModels.isEmpty() -> "No models available"
+            totalModelsCount > 0 -> "${filteredAvailableModels.size} shown ($totalModelsCount total)"
             else -> "${filteredAvailableModels.size} models available"
         }
     }

--- a/src/main/kotlin/org/zhavoronkov/openrouter/settings/FavoriteModelsSettingsPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/settings/FavoriteModelsSettingsPanel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.zhavoronkov.openrouter.models.OpenRouterModelInfo
 import org.zhavoronkov.openrouter.services.FavoriteModelsService
 import org.zhavoronkov.openrouter.services.OpenRouterSettingsService
@@ -613,18 +612,12 @@ class FavoriteModelsSettingsPanel : Disposable {
      */
     private fun loadTotalModelsCount() {
         coroutineScope.launch {
-            val result = withContext(Dispatchers.IO) {
-                favoriteModelsService.getOpenRouterService().getModelsCount()
-            }
-            when (result) {
-                is org.zhavoronkov.openrouter.models.ApiResult.Success -> {
-                    totalModelsCount = result.data.data.count
-                    PluginLogger.Settings.debug("Total models count: $totalModelsCount")
-                    updateStatusLabels()
-                }
-                is org.zhavoronkov.openrouter.models.ApiResult.Error -> {
-                    PluginLogger.Settings.debug("Failed to fetch total models count: ${result.message}")
-                }
+            totalModelsCount = favoriteModelsService.getModelsCount() ?: 0
+            if (totalModelsCount > 0) {
+                PluginLogger.Settings.debug("Total models count: $totalModelsCount")
+                updateStatusLabels()
+            } else {
+                PluginLogger.Settings.debug("Failed to fetch total models count")
             }
         }
     }

--- a/src/test/kotlin/org/zhavoronkov/openrouter/services/OpenRouterServicePublicEndpointsTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/services/OpenRouterServicePublicEndpointsTest.kt
@@ -94,4 +94,45 @@ class OpenRouterServicePublicEndpointsTest {
         assertEquals(1, success.data.data.size)
         assertEquals("openai", success.data.data.first().slug)
     }
+
+    @Test
+    fun `getModelsCount should parse response with output_modalities=all`() = runBlocking {
+        val response = """
+            {
+              "data": {
+                "count": 1234
+              }
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(response)
+        )
+
+        val result = service.getModelsCount()
+
+        assertTrue(result is ApiResult.Success)
+        val success = result as ApiResult.Success
+        assertEquals(1234, success.data.data.count)
+    }
+
+    @Test
+    fun `getModelsCount should request correct endpoint with query parameter`() = runBlocking {
+        val response = """{"data":{"count":1}}"""
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(response)
+        )
+
+        service.getModelsCount()
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/api/v1/models/count?output_modalities=all", request.path)
+    }
 }


### PR DESCRIPTION
This PR adds a total model count display to the Favorite Models settings panel by fetching from OpenRouter's `/models/count?output_modalities=all` endpoint. Users will now see "X shown (391 total)" instead of just the filtered count, providing better context about how many models match their filters vs. the full catalog.

### Changes

**New API integration:**
- Added `ModelsCountResponse` / `ModelsCountData` data classes for the count endpoint response
- Added `getModelsCountEndpoint()` endpoint getter
- Added `getModelsCount()` method in `OpenRouterService` using `output_modalities=all` to include all model types (text, image, audio, video)
- Added `getModelsCount()` wrapper in `FavoriteModelsService` with proper error handling and logging

**UI improvements:**
- Added `totalModelsCount` field to `FavoriteModelsSettingsPanel`
- Status label now shows `"X shown (Y total)"` when count is available
- Count is fetched asynchronously when the settings panel loads

**Code quality:**
- Migrated `withTimeout` call in `FavoriteModelsService` to use `Duration` overload (`API_TIMEOUT_MS.milliseconds`)
- Added `@Suppress("TooGenericExceptionCaught")` for the fallback exception handler

### Tests
- Added `getModelsCount should parse response with output_modalities=all`
- Added `getModelsCount should request correct endpoint with query parameter`

### Verification
- `./gradlew detekt --no-daemon` ✅
- `./gradlew build --no-daemon` ✅

### Reviewer notes
- Java **21** is required for stable Gradle execution
- The `output_modalities=all` parameter ensures non-text models (image generation, audio, etc.) are included in the count
