### PR TITLE
fix: include presets in AI Assistant model selection and modernize coroutine timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,5 +86,7 @@ coverage/
 test-results/
 junit.xml
 
+# Other
 ml-llm
 token-pulse/
+.mimocode

--- a/src/main/kotlin/org/zhavoronkov/openrouter/aiassistant/OpenRouterModelProvider.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/aiassistant/OpenRouterModelProvider.kt
@@ -2,6 +2,7 @@ package org.zhavoronkov.openrouter.aiassistant
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.milliseconds
 import org.zhavoronkov.openrouter.models.ApiResult
 import org.zhavoronkov.openrouter.models.OpenRouterModelInfo
 import org.zhavoronkov.openrouter.services.FavoriteModelsService
@@ -120,7 +121,7 @@ class OpenRouterModelProvider internal constructor(
 
             // Use the existing OpenRouterService test connection method
             runBlocking {
-                withTimeout(CONNECTION_TEST_TIMEOUT_MS) {
+                withTimeout(CONNECTION_TEST_TIMEOUT_MS.milliseconds) {
                     val result = openRouterService.testConnection()
                     when (result) {
                         is ApiResult.Success -> result.data

--- a/src/main/kotlin/org/zhavoronkov/openrouter/proxy/servlets/ModelsServlet.kt
+++ b/src/main/kotlin/org/zhavoronkov/openrouter/proxy/servlets/ModelsServlet.kt
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.milliseconds
 import org.zhavoronkov.openrouter.models.ApiResult
 import org.zhavoronkov.openrouter.proxy.models.OpenAIModel
 import org.zhavoronkov.openrouter.proxy.models.OpenAIModelsResponse
@@ -13,6 +14,7 @@ import org.zhavoronkov.openrouter.proxy.models.OpenAIPermission
 import org.zhavoronkov.openrouter.proxy.translation.ResponseTranslator
 import org.zhavoronkov.openrouter.services.OpenRouterService
 import org.zhavoronkov.openrouter.services.OpenRouterSettingsService
+import org.zhavoronkov.openrouter.services.settings.PresetsManager
 import org.zhavoronkov.openrouter.utils.PluginLogger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -25,6 +27,11 @@ class ModelsServlet(
     private val openRouterService: OpenRouterService,
     private val favoriteModelsProvider: () -> List<String> = {
         OpenRouterSettingsService.getInstance().favoriteModelsManager.getFavoriteModels()
+    },
+    private val presetsProvider: () -> List<String> = {
+        val settings = OpenRouterSettingsService.getInstance()
+        PresetsManager.BUILT_IN_PRESETS.map { it.id } +
+            settings.presetsManager.getCustomPresets().map { settings.presetsManager.getPresetModelId(it) }
     }
 ) : HttpServlet() {
 
@@ -128,8 +135,9 @@ class ModelsServlet(
     }
 
     private fun createCoreModelsResponse(): OpenAIModelsResponse {
-        // Return user's favorite models with FULL OpenRouter format (provider/model)
+        // Return presets first, then favorite models, with FULL OpenRouter format (provider/model)
         // This is critical - OpenRouter API requires full model names with provider prefix
+        val presetModelIds = presetsProvider()
         var favoriteModelIds = favoriteModelsProvider()
 
         // If no favorites are set, ensure we have defaults
@@ -146,7 +154,9 @@ class ModelsServlet(
             )
         }
 
-        val coreModels = favoriteModelIds.map { modelId ->
+        val allModelIds = presetModelIds + favoriteModelIds
+
+        val coreModels = allModelIds.map { modelId ->
             OpenAIModel(
                 id = modelId,
                 created = System.currentTimeMillis() / 1000, // Use current timestamp
@@ -178,7 +188,7 @@ class ModelsServlet(
         // Fetch from OpenRouter API
         return try {
             val result = runBlocking {
-                withTimeout(REQUEST_TIMEOUT_MS) {
+                withTimeout(REQUEST_TIMEOUT_MS.milliseconds) {
                     openRouterService.getModels()
                 }
             }

--- a/src/test/kotlin/org/zhavoronkov/openrouter/proxy/OpenRouterProxyServerTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/proxy/OpenRouterProxyServerTest.kt
@@ -90,7 +90,8 @@ class OpenRouterProxyServerTest {
         val modelsServlet = ServletHolder(
             ModelsServlet(
                 mockOpenRouterService,
-                favoriteModelsProvider = { listOf("openai/gpt-4o", "anthropic/claude-3.5-sonnet") }
+                favoriteModelsProvider = { listOf("openai/gpt-4o", "anthropic/claude-3.5-sonnet") },
+                presetsProvider = { listOf<String>() }
             )
         )
         val organizationServlet = ServletHolder(OrganizationServlet())

--- a/src/test/kotlin/org/zhavoronkov/openrouter/proxy/servlets/ModelsServletTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/openrouter/proxy/servlets/ModelsServletTest.kt
@@ -18,7 +18,8 @@ class ModelsServletTest {
     fun `doGet returns curated favorites`() {
         val openRouterService = mock(OpenRouterService::class.java)
         val favoritesProvider = { listOf("openai/gpt-4") }
-        val servlet = ModelsServlet(openRouterService, favoritesProvider)
+        val presetsProvider = { listOf<String>() }
+        val servlet = ModelsServlet(openRouterService, favoritesProvider, presetsProvider)
 
         val req = mock(HttpServletRequest::class.java)
         val resp = mock(HttpServletResponse::class.java)


### PR DESCRIPTION
## Summary

- **Fixes #48**: Custom presets (and built-in `openrouter/auto`, `openrouter/free`) now appear in the AI Assistant chat model selection dropdown
- Modernizes `withTimeout` calls to use `Duration` API instead of deprecated `Long` overload

## Changes

### Presets in AI Assistant model selection (`ModelsServlet.kt`)

The AI Assistant gets its model list from the proxy server's `/v1/models` endpoint. Previously, `ModelsServlet.createCoreModelsResponse()` only returned favorite models, ignoring presets entirely. This caused custom presets configured in Settings → Presets to be missing from the AI Assistant chat dropdown while appearing correctly in the OpenRouter chat panel.

Added a `presetsProvider` parameter that fetches both built-in and custom presets, and includes them in the response before favorites — matching the behavior of `ChatPanel.loadFavoriteModels()`.

### Coroutine timeout modernization

Converted legacy `withTimeout(Long)` calls to `withTimeout(Duration.milliseconds)` in:
- `ModelsServlet.kt` — `REQUEST_TIMEOUT_MS`
- `OpenRouterModelProvider.kt` — `CONNECTION_TEST_TIMEOUT_MS`

### Test updates

Updated `ModelsServletTest` and `OpenRouterProxyServerTest` to explicitly pass a `presetsProvider` lambda, preventing the default implementation from calling `OpenRouterSettingsService.getInstance()` in unit test context.

### Chores

- Added `.mimocode` to `.gitignore`