### PR TITLE
build: make detekt gate the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         cache-read-only: false  # Allow writing to cache on main/dev branches
 
     - name: Build and analyze
-      run: ./gradlew build detekt detektSarif --build-cache
+      run: ./gradlew build detekt --build-cache
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,30 +163,7 @@ detekt {
     buildUponDefaultConfig = true
     allRules = false
     config.setFrom("$projectDir/config/detekt/detekt.yml")
-    baseline = file("$projectDir/config/detekt/baseline.xml")
     basePath = projectDir.absolutePath
-}
-
-// Configure Detekt SARIF reporting task
-tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektSarif") {
-    description = "Runs detekt and generates SARIF report for GitHub Code Scanning"
-    group = "verification"
-
-    setSource(files("src/main/kotlin"))
-    include("**/*.kt")
-    exclude("**/test/**", "**/*Test.kt")
-
-    reports {
-        sarif.required.set(true)
-        sarif.outputLocation.set(file("build/reports/detekt/detekt.sarif"))
-        html.required.set(false)
-        txt.required.set(true)
-        xml.required.set(false)
-    }
-
-    jvmTarget = "21"
-    basePath = projectDir.absolutePath
-    ignoreFailures = true
 }
 
 tasks {
@@ -202,7 +179,13 @@ tasks {
     // Configure Detekt tasks
     withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         jvmTarget = "21"
-        ignoreFailures = true  // Don't fail the build on Detekt issues during development
+        // ignoreFailures is deliberately NOT set: lint gates the build.
+        reports {
+            sarif.required.set(true)
+            txt.required.set(true)
+            html.required.set(true)
+            xml.required.set(false)
+        }
     }
 
     // Configure tests

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" ?>
-<SmellBaseline>
-  <ManuallySuppressedIssues/>
-  <CurrentIssues/>
-</SmellBaseline>


### PR DESCRIPTION
Enable detekt as a build gate:
- Remove detekt baseline.xml (all findings fixed in #56)
- Set ignoreFailures=false in build.gradle.kts

This gates the build on detekt findings, ensuring code quality standards are maintained.

Depends on #56 (detekt findings must be fixed before gating can be enabled).