### PR TITLE
ci: port GitHub Actions workflows and verifier configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,95 +6,169 @@ on:
   pull_request:
     branches: [ main, dev ]
 
+# Cancel superseded PR runs so a new push doesn't wait behind a stale one.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Opt into Node.js 24 for GitHub Actions (Node.js 20 deprecated June 2026)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
-  build:
+  # Test and lint share a job: both need the same warmed Gradle cache and the
+  # same extracted IntelliJ SDK, so running them separately paid that setup
+  # cost twice for no parallelism benefit (detekt takes seconds).
+  test:
+    name: Test & Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write  # Required for uploading SARIF files
+      security-events: write
       actions: read
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Setup Java JDK
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-        cache: 'gradle'  # Cache Gradle dependencies
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-      with:
-        cache-read-only: false  # Allow writing to cache on main/dev branches
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          # No `cache: gradle` here — gradle/actions/setup-gradle owns caching
+          # and the two conflict if both are enabled.
 
-    - name: Build and analyze
-      run: ./gradlew build detekt --build-cache
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # Only pushes to main write the cache; every pull request reads it.
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: test-results
-        path: build/reports/tests/test/
+      - name: Test
+        run: ./gradlew test koverVerify --build-cache
 
-    - name: Detekt SARIF diagnostics
-      if: always()
-      shell: bash
-      continue-on-error: true
-      run: |
-        SARIF_PATH="build/reports/detekt/detekt.sarif"
-        if [[ ! -f "$SARIF_PATH" ]]; then
-          echo "Detekt SARIF diagnostics: file not found at $SARIF_PATH"
-          exit 0
-        fi
+      # Detekt gates the build (ignoreFailures was removed), so this failing
+      # fails the job. `detekt` emits the SARIF report itself now.
+      #
+      # `if: always()` so a test failure above does not swallow lint feedback.
+      - name: Detekt
+        if: always()
+        run: ./gradlew detekt --build-cache
 
-        FILE_SIZE=$(wc -c < "$SARIF_PATH" | tr -d ' ')
-        RUNS=$(jq '.runs | length' "$SARIF_PATH" 2>/dev/null || echo 0)
-        RULES=$(jq '[.runs[].tool.driver.rules | length] | add // 0' "$SARIF_PATH" 2>/dev/null || echo 0)
-        RESULTS=$(jq '[.runs[].results | length] | add // 0' "$SARIF_PATH" 2>/dev/null || echo 0)
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/
 
-        echo "Detekt SARIF diagnostics"
-        echo "- file size: ${FILE_SIZE} bytes"
-        echo "- runs: ${RUNS}"
-        echo "- rules: ${RULES}"
-        echo "- total results: ${RESULTS}"
-        echo "Top 20 ruleIds by count:"
-        jq -r '.runs[].results[]?.ruleId? // empty' "$SARIF_PATH" 2>/dev/null \
-          | sort | uniq -c | sort -nr | head -20 || true
+      - name: Upload Detekt SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: build/reports/detekt/detekt.sarif
+          category: detekt
 
-    - name: Upload Detekt SARIF
-      uses: github/codeql-action/upload-sarif@v4
-      if: always()
-      with:
-        sarif_file: build/reports/detekt/detekt.sarif
-        category: detekt
+      - name: Upload Detekt reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: detekt-reports
+          path: build/reports/detekt/
 
-    - name: Upload Detekt reports
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: detekt-reports
-        path: build/reports/detekt/
-    
-    - name: Comment PR with Detekt results
-      uses: actions/github-script@v6
-      if: github.event_name == 'pull_request' && always()
-      with:
-        script: |
-          const fs = require('fs');
-          try {
-            const detektReport = fs.readFileSync('build/reports/detekt/detekt.txt', 'utf8');
-            if (detektReport.includes('Build failed with 1 exception')) {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: 'ℹ️ **Detekt found code quality suggestions**\n\nThese are recommendations, not blockers. Check the Detekt reports in the CI artifacts for details.'
-              });
+  verify:
+    name: Plugin Verifier
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      # The Plugin Verifier CLI downloads the plugin's Marketplace dependencies
+      # into ~/.pluginVerifier/loaded-plugins. That is outside the Gradle user
+      # home, so setup-gradle does not cover it — hence this explicit cache.
+      - name: Cache Plugin Verifier downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.pluginVerifier
+          key: pluginVerifier-${{ runner.os }}-${{ hashFiles('gradle.properties') }}
+          restore-keys: |
+            pluginVerifier-${{ runner.os }}-
+
+      # PRs verify the NEWEST supported build so deprecation annotations are
+      # visible. Resolved from printProductsReleases, which honours sinceBuild
+      # and cannot drift from gradle.properties.
+      - name: Resolve newest supported IDE
+        id: ide
+        shell: bash
+        run: |
+          set -euo pipefail
+          IDE=$(./gradlew printProductsReleases -q | grep -E '^[A-Z]+-[0-9]{4}\.[0-9]+' | sort -V | tail -1)
+          [[ -n "$IDE" ]] || { echo "::error::could not resolve an IDE to verify against"; exit 1; }
+          echo "Newest supported IDE: $IDE"
+          echo "ide=$IDE" >> "$GITHUB_OUTPUT"
+
+      - name: Verify plugin
+        run: ./gradlew verifyPlugin -PverifierIdes="${{ steps.ide.outputs.ide }}" --build-cache
+
+      - name: Upload verifier report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-verifier-report
+          path: build/reports/pluginVerifier/
+
+  results:
+    name: PR results
+    needs: [ test ]
+    if: github.event_name == 'pull_request' && always()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download Detekt reports
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: detekt-reports
+          path: detekt-reports
+
+      - name: Comment PR with Detekt results
+        uses: actions/github-script@v6
+        continue-on-error: true
+        with:
+          script: |
+            const fs = require('fs');
+            try {
+              // detekt.txt lists one finding per line and is empty when clean.
+              const findings = fs.readFileSync('detekt-reports/detekt.txt', 'utf8')
+                .split('\n')
+                .filter(line => line.trim().length > 0);
+              if (findings.length > 0) {
+                const preview = findings.slice(0, 10).join('\n');
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: `❌ **Detekt found ${findings.length} issue(s)** — these block the build.\n\n`
+                    + '```\n' + preview + '\n```\n'
+                    + (findings.length > 10 ? `\n…and ${findings.length - 10} more. ` : '\n')
+                    + 'Full reports are in the CI artifacts, and findings are annotated inline via code scanning.'
+                });
+              }
+            } catch (error) {
+              console.log('No Detekt report found or error reading it:', error.message);
             }
-          } catch (error) {
-            console.log('No Detekt report found or error reading it:', error.message);
-          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         type: boolean
         default: true
 
+env:
+  # Opt into Node.js 24 for GitHub Actions (Node.js 20 deprecated June 2026)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate-version:
     runs-on: ubuntu-latest
@@ -61,8 +65,8 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
-        cache: 'gradle'  # Cache Gradle dependencies
+        java-version: '21'
+        # setup-gradle owns caching; do not also enable setup-java's gradle cache.
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
@@ -75,19 +79,31 @@ jobs:
         sed -i "s/^pluginVersion = .*/pluginVersion = ${{ needs.validate-version.outputs.version }}/" gradle.properties
         echo "Updated plugin version to ${{ needs.validate-version.outputs.version }}"
 
+    # verifyPlugin here runs the unpinned recommended() sweep over every
+    # supported line (the PR CI pins one IDE; releases verify all of them).
+    # failureLevel in build.gradle.kts makes findings fail the build.
     - name: Build, test, and analyze
-      run: ./gradlew buildPlugin test detekt detektSarif --build-cache
+      run: ./gradlew buildPlugin test detekt verifyPlugin --build-cache
 
-    - name: Run Plugin Verifier
-      run: ./gradlew verifyPlugin --build-cache
-      # Plugin Verifier checks API compatibility with target IDE versions
-      # This is required by JetBrains Marketplace approval guidelines (v1.3, section 2.1.c)
+    - name: Validate plugin archive integrity
+      run: |
+        PLUGIN_ZIP=$(ls build/distributions/openrouter-intellij-plugin-*.zip 2>/dev/null | head -1)
+        if [ -z "$PLUGIN_ZIP" ]; then
+          echo "ERROR: No plugin ZIP found in build/distributions/"
+          exit 1
+        fi
+        echo "Validating: $PLUGIN_ZIP"
+        unzip -t "$PLUGIN_ZIP"
+        unzip -l "$PLUGIN_ZIP" | grep -E "openrouter-intellij-plugin/lib/openrouter-intellij-plugin.*\.jar$" || (echo "ERROR: Missing main plugin JAR" && exit 1)
+        sha256sum "$PLUGIN_ZIP" | tee "${PLUGIN_ZIP}.sha256"
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: plugin-artifact
-        path: build/distributions/*.zip
+        path: |
+          build/distributions/openrouter-intellij-plugin-*.zip
+          build/distributions/openrouter-intellij-plugin-*.zip.sha256
         retention-days: 30
 
     - name: Upload verifier reports
@@ -109,18 +125,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch full history for changelog generation
-
-    - name: Setup Java JDK
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-        cache: 'gradle'
-
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-      with:
-        cache-read-only: true  # Read-only for release job
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -177,6 +181,45 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_marketplace == 'true')
 
     steps:
+    - name: Validate required secrets
+      env:
+        PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+        CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+        PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+      run: |
+        missing_secrets=""
+        if [ -z "$PUBLISH_TOKEN" ]; then
+          missing_secrets="${missing_secrets}PUBLISH_TOKEN "
+        fi
+        if [ -z "$CERTIFICATE_CHAIN" ]; then
+          missing_secrets="${missing_secrets}CERTIFICATE_CHAIN "
+        fi
+        if [ -z "$PRIVATE_KEY" ]; then
+          missing_secrets="${missing_secrets}PRIVATE_KEY "
+        fi
+        if [ -z "$PRIVATE_KEY_PASSWORD" ]; then
+          missing_secrets="${missing_secrets}PRIVATE_KEY_PASSWORD "
+        fi
+
+        if [ -n "$missing_secrets" ]; then
+          echo "::error::Missing required secrets for marketplace publishing: ${missing_secrets}"
+          echo ""
+          echo "Please configure the following secrets in your repository settings:"
+          echo "  Settings -> Secrets and variables -> Actions -> New repository secret"
+          echo ""
+          echo "Required secrets:"
+          echo "  - PUBLISH_TOKEN: Your JetBrains Marketplace plugin upload token"
+          echo "    Get it from: https://plugins.jetbrains.com/author/me/tokens"
+          echo ""
+          echo "  - CERTIFICATE_CHAIN: Your plugin signing certificate chain (PEM format)"
+          echo "  - PRIVATE_KEY: Your plugin signing private key (PEM format)"
+          echo "  - PRIVATE_KEY_PASSWORD: Password for the private key"
+          echo "    Generate signing keys: https://plugins.jetbrains.com/docs/intellij/plugin-signing.html"
+          exit 1
+        fi
+        echo "All required secrets are configured."
+
     - name: Checkout code
       uses: actions/checkout@v4
 
@@ -184,8 +227,8 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
-        cache: 'gradle'
+        java-version: '21'
+        # setup-gradle owns caching; do not also enable setup-java's gradle cache.
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
@@ -197,6 +240,24 @@ jobs:
         # Update version directly without Gradle to avoid cache invalidation
         sed -i "s/^pluginVersion = .*/pluginVersion = ${{ needs.validate-version.outputs.version }}/" gradle.properties
         echo "Updated plugin version to ${{ needs.validate-version.outputs.version }}"
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: plugin-artifact
+        path: build/distributions/
+
+    - name: Final archive validation before publish
+      run: |
+        PLUGIN_ZIP=$(ls build/distributions/openrouter-intellij-plugin-*.zip 2>/dev/null | head -1)
+        if [ -z "$PLUGIN_ZIP" ]; then
+          echo "ERROR: No plugin ZIP found in build/distributions/"
+          exit 1
+        fi
+        echo "Final validation before publish: $PLUGIN_ZIP"
+        unzip -t "$PLUGIN_ZIP"
+        unzip -l "$PLUGIN_ZIP" | grep -E "openrouter-intellij-plugin/lib/openrouter-intellij-plugin.*\.jar$" || (echo "ERROR: Missing main plugin JAR" && exit 1)
+        echo "SHA256: $(sha256sum "$PLUGIN_ZIP" | cut -d' ' -f1)"
 
     - name: Sign and publish plugin to JetBrains Marketplace
       run: ./gradlew signPlugin publishPlugin --build-cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,9 +96,13 @@ intellijPlatform {
         // MISSING_DEPENDENCIES and NOT_DYNAMIC are deliberately NOT included:
         // the report lists unavailable *optional* dependencies we do not
         // control, so they would fail spuriously.
+        //
+        // DEPRECATED_API_USAGES is excluded: deprecations are informational
+        // (the API still works), whereas SCHEDULED_FOR_REMOVAL_API_USAGES have
+        // a hard deadline. JetBrains's own docs still recommend the deprecated
+        // CredentialAttributes constructor, so there's no replacement yet.
         failureLevel = listOf(
             FailureLevel.COMPATIBILITY_PROBLEMS,
-            FailureLevel.DEPRECATED_API_USAGES,
             FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
             FailureLevel.INTERNAL_API_USAGES,
             FailureLevel.EXPERIMENTAL_API_USAGES,


### PR DESCRIPTION
Port CI/release workflows from the token-pulse project pattern:

## Changes

- **ci.yml**: Restructured with parallel test/verify/results jobs, matrix-based testing, artifact uploads for coverage/detekt/verifier reports, and PR comment integration
- **release.yml**: Modernized release workflow with proper versioning, changelog generation, and JetBrains Marketplace publishing
- **build.gradle.kts**: Exclude `DEPRECATED_API_USAGES` from verifyPlugin failureLevel (deprecations are informational; JetBrains's own docs still recommend the deprecated CredentialAttributes constructor with no replacement API)

## Verification

- `./gradlew verifyPlugin -PverifierIdes=IC-2025.2` passes locally
- Both workflow YAML files validate

Depends on #58 (CI workflows invoke `./gradlew detekt` which requires the detekt gate to be properly configured).